### PR TITLE
Let process succeed even if no matches

### DIFF
--- a/src/dbdiff/__init__.py
+++ b/src/dbdiff/__init__.py
@@ -4,4 +4,4 @@
 # See that warning on Step 6 here:
 # https://packaging.python.org/guides/single-sourcing-package-version/
 # If we want to do imports here, there is a different approach.
-__version__ = '0.6.5'
+__version__ = '0.6.6'

--- a/src/dbdiff/main.py
+++ b/src/dbdiff/main.py
@@ -357,7 +357,11 @@ def get_diff_rows_from_joined(cur: Cursor,
     diff_total_count = sum([info['count'] for info in grouped_column_diffs.values()])
     if skip_row_total or (len(grouped_column_diffs) == 0):
         LOGGER.debug("Skipping sample of rows with differences, query to get that sample, and the total # of rows with > 0 differences. Returning only 'total_count', the sum of cell-by-cell differences.")
-        return {'total_count': diff_total_count}
+        return {
+            'sample': [],
+            'count': 0,
+            'total_count': diff_total_count
+        }
 
     LOGGER.info(grouped_column_diffs)
     q = JINJA_ENV.get_template('joined_rows_count.sql').render(


### PR DESCRIPTION
Given a `{base_table}_JOINED` table in Vertica that is empty, creating the report fails with errors such as:

```
summary_sheet_data.append({'Summary': "There are {diff_row_count} rows matched between tables that don't line up exactly.".format(diff_row_count=diff_summary['count'])})
KeyError: 'count'
```

The reason for this is because https://github.com/andyreagan/dbdiff/blob/c7f4801e8a568645402fa51b38d770f046271297/src/dbdiff/main.py#L358 this line returns `0` from the second condition which forces the function to return a dictionary with a single key value pair in it. This however, ends up breaking the report because the report expects the `count` key to be present as shown https://github.com/andyreagan/dbdiff/blob/c7f4801e8a568645402fa51b38d770f046271297/src/dbdiff/report.py#L96

Overall, this should probably be handled a layer lower, probably in https://github.com/andyreagan/dbdiff/blob/c7f4801e8a568645402fa51b38d770f046271297/src/dbdiff/cli.py#L318 to tell the program to not even assemble the report, as there is nothing to show (if in fact nothing joins between the two tables).