### PR TITLE
chore: monthly maintenance — March 2026

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -250,7 +250,7 @@ toml = [
 
 [[package]]
 name = "dbdiff"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },


### PR DESCRIPTION
Automated monthly maintenance for **dbdiff**.

### Steps
- ✅ pre-commit autoupdate
- ✅ pre-commit run --all-files
- ✅ uv lock --upgrade
- ✅ uv sync
- ❌ uv run pytest

Dependency lag date: `2026-03-06`

Generated by `maintain.py` on 2026-03-13.