### PR TITLE
feat: add DuckDB backend for in-process table comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,16 @@ Issues = "https://github.com/andyreagan/dbdiff/issues"
 [project.scripts]
 dbdiff = "dbdiff.cli:cli"
 
+[project.optional-dependencies]
+duckdb = ["duckdb"]
+
 [dependency-groups]
 dev = [
     "pytest",
     "pytest-cov",
     "click",
     "sqlglot",
+    "duckdb",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -70,6 +74,7 @@ addopts = [
 ]
 markers = [
     "integration: requires a running Vertica instance",
+    "duckdb_integration: integration tests using DuckDB (no external server required)",
 ]
 testpaths = ["tests"]
 

--- a/src/dbdiff/cli.py
+++ b/src/dbdiff/cli.py
@@ -7,7 +7,6 @@ from typing import Any
 import click
 import pandas as pd
 from jinja2 import Environment, PackageLoader
-from vertica_python.vertica.cursor import Cursor
 
 from dbdiff import __version__
 from dbdiff.main import (
@@ -27,7 +26,6 @@ from dbdiff.main import (
     set_dialect,
 )
 from dbdiff.report import excel_report, html_report
-from dbdiff.vertica import get_cur
 
 JINJA_ENV = Environment(loader=PackageLoader("dbdiff", "templates"))
 DEFAULT_LOGGING_CONFIG = Path(__file__).with_name("logging.json")
@@ -201,7 +199,14 @@ def cli(
     exclude_columns_set = set(map(lambda x: x.lower(), exclude_columns.split(",")))
     initialize_logging(logging_config)
 
-    with get_cur() as cur:
+    if dialect == "duckdb":
+        from dbdiff.duckdb_backend import get_duckdb_cur
+        get_cur_fn = get_duckdb_cur
+    else:
+        from dbdiff.vertica import get_cur
+        get_cur_fn = get_cur
+
+    with get_cur_fn() as cur:
         if x_table_query:
             with open(x_table) as f:
                 q = f.read()
@@ -265,7 +270,7 @@ def cli(
 
 
 def main(
-    cur: Cursor,
+    cur,
     x_schema: str,
     x_table: str,
     y_schema: str,
@@ -357,6 +362,8 @@ def main(
         hierarchical_join_info = {}
 
     # create sub-tables to allow a comparison:
+    # Temp tables with v_temp_schema are Vertica-specific; skip for other dialects
+    use_vertica_temp = dialect == "vertica"
     if x != 0:
         LOGGER.info("X table was not unique on join keys, creating _dedup and _dup versions.")
         schema, x_table = select_distinct_rows(
@@ -364,7 +371,7 @@ def main(
             x_schema,
             x_table,
             join_cols,
-            use_temp_tables=(drop_output_tables or x_schema == "v_temp_schema"),
+            use_temp_tables=(use_vertica_temp and (drop_output_tables or x_schema == "v_temp_schema")),
         )
     if y != 0:
         LOGGER.info("Y table was not unique on join keys, creating _dedup and _dup versions.")
@@ -373,7 +380,7 @@ def main(
             y_schema,
             y_table,
             join_cols,
-            use_temp_tables=(drop_output_tables or y_schema == "v_temp_schema"),
+            use_temp_tables=(use_vertica_temp and (drop_output_tables or y_schema == "v_temp_schema")),
         )
 
     LOGGER.info("Getting rows that did not match (not in joined table) after deduping.")

--- a/src/dbdiff/duckdb_backend.py
+++ b/src/dbdiff/duckdb_backend.py
@@ -1,0 +1,123 @@
+"""DuckDB backend for dbdiff.
+
+Provides a cursor wrapper and helper functions that match the interface
+used by the Vertica backend, allowing dbdiff to run entirely in-process
+against DuckDB.
+"""
+
+import logging
+from contextlib import contextmanager
+
+import duckdb
+import pandas as pd
+from jinja2 import Environment, PackageLoader
+
+JINJA_ENV = Environment(loader=PackageLoader("dbdiff", "templates"))
+LOGGER = logging.getLogger(__name__)
+
+
+class DuckDBCursorWrapper:
+    """Wraps a duckdb.DuckDBPyConnection to provide a dict-cursor interface
+    compatible with vertica_python's dict cursor."""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self._conn = conn
+        self._description = None
+
+    def execute(self, sql: str) -> "DuckDBCursorWrapper":
+        sql_stripped = sql.strip().rstrip(";").strip()
+        # DuckDB auto-commits; skip explicit COMMIT statements
+        if sql_stripped.upper() == "COMMIT":
+            return self
+        self._conn.execute(sql)
+        self._description = self._conn.description
+        return self
+
+    def fetchall(self) -> list[dict]:
+        if self._description is None:
+            return []
+        columns = [self._normalize_col_name(desc[0]) for desc in self._description]
+        rows = self._conn.fetchall()
+        return [dict(zip(columns, row)) for row in rows]
+
+    @staticmethod
+    def _normalize_col_name(name: str) -> str:
+        """Normalize DuckDB column names to match Vertica conventions.
+
+        DuckDB uses 'count_star()' for COUNT(*), while Vertica uses 'COUNT'.
+        """
+        if name == "count_star()":
+            return "COUNT"
+        return name
+
+    @property
+    def description(self):
+        return self._description
+
+
+@contextmanager
+def get_duckdb_cur(database: str = ":memory:"):
+    """Context manager that yields a DuckDB cursor wrapper.
+
+    Args:
+        database: Path to DuckDB database file, or ":memory:" for in-memory.
+    """
+    conn = duckdb.connect(database)
+    try:
+        yield DuckDBCursorWrapper(conn)
+    finally:
+        conn.close()
+
+
+def get_column_info(cur: DuckDBCursorWrapper, schema_name: str, table_name: str) -> pd.DataFrame:
+    """Get column info from DuckDB's information_schema."""
+    column_template = JINJA_ENV.get_template("table_columns.sql")
+    cur.execute(column_template.render(schema_name=schema_name, table_name=table_name, dialect="duckdb"))
+    df = pd.DataFrame(cur.fetchall())
+    if df.shape[0] == 0:
+        raise RuntimeError(f"{schema_name}.{table_name} has no columns.")
+    return df
+
+
+def get_column_info_lookup(cur: DuckDBCursorWrapper, schema_name: str, table_name: str) -> dict:
+    x_table_info = get_column_info(cur, schema_name, table_name)
+    LOGGER.info(
+        "Column info DuckDB for "
+        + schema_name
+        + "."
+        + table_name
+        + ":\n"
+        + x_table_info.head().to_string()
+        + "\n..."
+    )
+    x_table_info["column_name"] = x_table_info["column_name"].str.lower()
+    return {r.column_name: r.data_type for i, r in x_table_info.iterrows()}
+
+
+def get_table_exists(cur: DuckDBCursorWrapper, schema_name: str, table_name: str) -> bool:
+    table_exists_template = JINJA_ENV.get_template("table_exists.sql")
+    cur.execute(table_exists_template.render(schema_name=schema_name, table_name=table_name, dialect="duckdb"))
+    result = cur.fetchall()
+    return result[0]["COUNT"] == 1
+
+
+def implicit_dtype_comparison(x_dtype: str, y_dtype: str) -> bool:
+    """Can x_dtype be implicitly converted to y_dtype in DuckDB?
+
+    DuckDB is generally more permissive with implicit casts than Vertica,
+    but we use similar rules for consistency.
+    """
+    source = x_dtype.upper()
+    target = y_dtype.upper()
+    if "INT" in source:
+        return "BOOL" in target or "NUMERIC" in target or "FLOAT" in target or "INT" in target or "BIGINT" in target
+    elif "NUMERIC" in source or "DECIMAL" in source:
+        return "FLOAT" in target or "NUMERIC" in target or "DECIMAL" in target
+    elif "CHAR" in source or "VARCHAR" in source or "TEXT" in source:
+        return "CHAR" in target or "VARCHAR" in target or "TEXT" in target or "FLOAT" in target
+    elif "DATE" in source and "DATE" in target:
+        return True
+    elif "TIMESTAMP" in source and "TIMESTAMP" in target:
+        return True
+    else:
+        return source == target

--- a/src/dbdiff/main.py
+++ b/src/dbdiff/main.py
@@ -5,9 +5,26 @@ from typing import Any
 
 import pandas as pd
 from jinja2 import Environment, PackageLoader
-from vertica_python.vertica.cursor import Cursor
 
-from dbdiff.vertica import get_column_info_lookup, implicit_dtype_comparison
+from dbdiff.vertica import get_column_info_lookup as vertica_get_column_info_lookup
+from dbdiff.vertica import implicit_dtype_comparison as vertica_implicit_dtype_comparison
+
+# Current dialect, set by set_dialect()
+_current_dialect = "vertica"
+
+
+def _get_column_info_lookup(cur, schema_name, table_name):
+    if _current_dialect == "duckdb":
+        from dbdiff.duckdb_backend import get_column_info_lookup as duckdb_get_column_info_lookup
+        return duckdb_get_column_info_lookup(cur, schema_name, table_name)
+    return vertica_get_column_info_lookup(cur, schema_name, table_name)
+
+
+def _implicit_dtype_comparison(x_dtype, y_dtype):
+    if _current_dialect == "duckdb":
+        from dbdiff.duckdb_backend import implicit_dtype_comparison as duckdb_implicit_dtype_comparison
+        return duckdb_implicit_dtype_comparison(x_dtype, y_dtype)
+    return vertica_implicit_dtype_comparison(x_dtype, y_dtype)
 
 JINJA_ENV = Environment(loader=PackageLoader("dbdiff", "templates"))
 LOGGER = logging.getLogger(__name__)
@@ -15,7 +32,16 @@ LOGGER = logging.getLogger(__name__)
 
 def set_dialect(dialect: str = "vertica") -> None:
     """Set the SQL dialect for template rendering."""
+    global _current_dialect
+    _current_dialect = dialect
     JINJA_ENV.globals["dialect"] = dialect
+
+
+def _null_safe_eq(left_alias: str, col: str, right_alias: str) -> str:
+    """Return a null-safe equality expression for the current dialect."""
+    if _current_dialect == "vertica":
+        return f"{left_alias}.{col} <=> {right_alias}.{col}"
+    return f"{left_alias}.{col} IS NOT DISTINCT FROM {right_alias}.{col}"
 
 
 def is_numeric_like(dtype: str):
@@ -28,7 +54,7 @@ def is_date_like(dtype: str):
     return "date" in dtype_l
 
 
-def check_primary_key(cur: Cursor, schema: str, table: str, join_cols: list) -> int:
+def check_primary_key(cur, schema: str, table: str, join_cols: list) -> int:
     """Given a list of columns return the # of records for which they are NOT
     a primary key."""
 
@@ -47,7 +73,7 @@ def check_primary_key(cur: Cursor, schema: str, table: str, join_cols: list) -> 
 
 
 def get_all_col_info(
-    cur: Cursor,
+    cur,
     schema,
     x_table,
     y_schema,
@@ -57,14 +83,14 @@ def get_all_col_info(
     save_column_summary_format,
 ) -> pd.DataFrame:
     LOGGER.info("Getting column info for both tables.")
-    x_table_info_lookup = get_column_info_lookup(cur, schema, x_table)
-    y_table_info_lookup = get_column_info_lookup(cur, y_schema, y_table)
+    x_table_info_lookup = _get_column_info_lookup(cur, schema, x_table)
+    y_table_info_lookup = _get_column_info_lookup(cur, y_schema, y_table)
 
     def comparable_(x, y) -> bool:
         # this doesn't capture the case where they both could be converted to float to be compared (two hop conversions):
         if (x is None) or (y is None):
             return False
-        x_or_y = implicit_dtype_comparison(x, y) or implicit_dtype_comparison(y, x)
+        x_or_y = _implicit_dtype_comparison(x, y) or _implicit_dtype_comparison(y, x)
         return x_or_y
 
     all_keys = list(x_table_info_lookup.keys()) + list(y_table_info_lookup.keys())
@@ -108,7 +134,7 @@ def get_all_col_info(
 
 
 def select_distinct_rows(
-    cur: Cursor, schema: str, table: str, join_cols: list, use_temp_tables: bool = False
+    cur, schema: str, table: str, join_cols: list, use_temp_tables: bool = False
 ) -> tuple[str, str]:
     """Select only the rows that are distinct on join_cols.
     *Instead of deleting the rows, we'll select those without duplicates into a
@@ -121,12 +147,16 @@ def select_distinct_rows(
     )
     LOGGER.info(drop_q)
     cur.execute(drop_q)
+    if _current_dialect == "vertica":
+        join_expr = " AND ".join([_null_safe_eq("x", col, "y") for col in join_cols])
+    else:
+        join_expr = " AND ".join(["x.{0} IS NOT DISTINCT FROM y.{0}".format(col) for col in join_cols])
     q = JINJA_ENV.get_template("create_dedup.sql").render(
         schema_name=schema,
         table_name=table,
         table_name_dedup=(table + "_dedup"),
         group_cols=", ".join(join_cols),
-        join_cols=" AND ".join(["x.{0} <=> y.{0}".format(col) for col in join_cols]),
+        join_cols=join_expr,
         use_temp_table=use_temp_tables,
     )
     if use_temp_tables:
@@ -147,7 +177,7 @@ def select_distinct_rows(
         table_name=table,
         table_name_dup=(table + "_dup"),
         group_cols=", ".join(join_cols),
-        join_cols=" AND ".join(["x.{0} <=> y.{0}".format(col) for col in join_cols]),
+        join_cols=join_expr,
         use_temp_table=use_temp_tables,
     )
     if use_temp_tables:
@@ -162,7 +192,7 @@ def select_distinct_rows(
     return (schema, "v_temp_schema")[use_temp_tables], f"{table}_dedup"
 
 
-def create_joined_table(cur: Cursor, create_insert=False, **kwargs):
+def create_joined_table(cur, create_insert=False, **kwargs):
     """
     Joins two tables x and y.
     :param cur: vertica python Cursor
@@ -203,7 +233,7 @@ def create_joined_table(cur: Cursor, create_insert=False, **kwargs):
 
 
 def get_unmatched_rows_straight(
-    cur: Cursor,
+    cur,
     x_schema: str,
     y_schema: str,
     x_table: str,
@@ -244,7 +274,7 @@ def get_unmatched_rows_straight(
 
 
 def get_unmatched_rows(
-    cur: Cursor,
+    cur,
     x_schema: str,
     y_schema: str,
     x_table: str,
@@ -332,7 +362,7 @@ def get_unmatched_rows(
 
 
 def create_diff_table(
-    cur: Cursor, schema: str, table: str, join_cols: list, all_col_info_df: pd.DataFrame
+    cur, schema: str, table: str, join_cols: list, all_col_info_df: pd.DataFrame
 ) -> str:
     drop_q = JINJA_ENV.get_template("table_drop.sql").render(schema_name=schema, table_name=table)
     # so simple that putting into a template would make this harder to follow...
@@ -350,13 +380,13 @@ def create_diff_table(
     return q
 
 
-def insert_diff_table(cur: Cursor, **kwargs) -> None:
+def insert_diff_table(cur, **kwargs) -> None:
     cur.execute(JINJA_ENV.get_template("insert_diff.sql").render(kwargs))
     cur.execute("COMMIT;")
 
 
 def get_diff_rows(
-    cur: Cursor,
+    cur,
     output_schema: str,
     x_table: str,
     join_cols: list,
@@ -390,7 +420,7 @@ def get_diff_rows(
         joined_table=(x_table + "_JOINED"),
         diff_table=(x_table + "_DIFF"),
         group_cols=", ".join(join_cols),
-        join_cols=" AND ".join(["x.{0} <=> joined.{0}".format(col) for col in join_cols]),
+        join_cols=" AND ".join([_null_safe_eq("x", col, "joined") for col in join_cols]),
     )
     LOGGER.info(q)
     cur.execute(q + " LIMIT " + str(max_rows_all))
@@ -405,7 +435,7 @@ def get_diff_rows(
 
 
 def get_diff_rows_from_joined(
-    cur: Cursor,
+    cur,
     grouped_column_diffs: dict,
     output_schema: str,
     x_table: str,
@@ -466,7 +496,7 @@ def get_diff_rows_from_joined(
     }
 
 
-def get_diff_columns(cur: Cursor, output_schema: str, x_table: str) -> pd.DataFrame:
+def get_diff_columns(cur, output_schema: str, x_table: str) -> pd.DataFrame:
     LOGGER.debug("Getting diff columns")
     # The # of columns has a hard limit (~1600 in Vertica?) so don't worry about
     # pulling the count first or limiting the results
@@ -479,7 +509,7 @@ def get_diff_columns(cur: Cursor, output_schema: str, x_table: str) -> pd.DataFr
 
 def get_column_diffs(
     diff_columns: pd.DataFrame,
-    cur: Cursor,
+    cur,
     output_schema: str,
     x_schema: str,
     x_table: str,
@@ -512,7 +542,7 @@ def get_column_diffs(
             diff_schema=output_schema,
             diff_table=(x_table + "_DIFF"),
             group_cols=", ".join(join_cols),
-            join_cols=" AND ".join(["diff.{0} <=> joined.{0}".format(col) for col in join_cols]),
+            join_cols=" AND ".join([_null_safe_eq("diff", col, "joined") for col in join_cols]),
         )
         info["q"] = q
         q_raw = JINJA_ENV.get_template("diff_column_raw.sql").render(
@@ -523,7 +553,7 @@ def get_column_diffs(
             diff_table=(x_table + "_DIFF"),
             join_cols=join_cols,
             join_cols_join=" AND ".join(
-                ["diff.{0} <=> joined.{0}".format(col) for col in join_cols]
+                [_null_safe_eq("diff", col, "joined") for col in join_cols]
             ),
         )
         info["q_raw"] = q_raw
@@ -561,7 +591,7 @@ def get_column_diffs(
                 diff_table=(x_table + "_DIFF"),
                 group_cols=", ".join(join_cols),
                 join_cols=" AND ".join(
-                    ["diff.{0} <=> joined.{0}".format(col) for col in join_cols]
+                    [_null_safe_eq("diff", col, "joined") for col in join_cols]
                 ),
                 tiles=min({max({1, info["count"]}), 10}),
             )
@@ -577,7 +607,7 @@ def get_column_diffs(
                 diff_table=(x_table + "_DIFF"),
                 join_cols=join_cols,
                 join_cols_join=" AND ".join(
-                    ["diff.{0} <=> joined.{0}".format(col) for col in join_cols]
+                    [_null_safe_eq("diff", col, "joined") for col in join_cols]
                 ),
             )
             cur.execute(info["q_n_sample"] + " LIMIT " + str(max_rows_column))
@@ -586,7 +616,7 @@ def get_column_diffs(
 
 
 def get_column_diffs_from_joined(
-    cur: Cursor,
+    cur,
     output_schema: str,
     x_schema: str,
     x_table: str,

--- a/src/dbdiff/templates/create_dedup.sql
+++ b/src/dbdiff/templates/create_dedup.sql
@@ -1,5 +1,6 @@
+{% if not use_temp_table and dialect != "vertica" %}CREATE TABLE {{ schema_name }}.{{ table_name_dedup }} AS {% endif -%}
     SELECT x.*
-{% if not use_temp_table %}INTO {{ schema_name }}.{{ table_name_dedup }}{% endif %}
+{% if not use_temp_table and dialect == "vertica" %}INTO {{ schema_name }}.{{ table_name_dedup }}{% endif %}
       FROM {{ schema_name }}.{{ table_name }} x
 INNER JOIN (
     SELECT {{ group_cols }},

--- a/src/dbdiff/templates/create_dup.sql
+++ b/src/dbdiff/templates/create_dup.sql
@@ -1,5 +1,6 @@
+{% if not use_temp_table and dialect != "vertica" %}CREATE TABLE {{ schema_name }}.{{ table_name_dup }} AS {% endif -%}
     SELECT x.*, y.dup_count
-{% if not use_temp_table %}INTO {{ schema_name }}.{{ table_name_dup }}{% endif %}
+{% if not use_temp_table and dialect == "vertica" %}INTO {{ schema_name }}.{{ table_name_dup }}{% endif %}
       FROM {{ schema_name }}.{{ table_name }} x
 INNER JOIN (
     SELECT {{ group_cols }},

--- a/src/dbdiff/templates/create_temp_table.sql
+++ b/src/dbdiff/templates/create_temp_table.sql
@@ -1,1 +1,5 @@
+{% if dialect == "vertica" -%}
 CREATE LOCAL TEMP TABLE {{ table_name }} ON COMMIT PRESERVE ROWS AS ({{ query }})
+{%- else -%}
+CREATE TEMP TABLE {{ table_name }} AS ({{ query }})
+{%- endif %}

--- a/src/dbdiff/templates/table_columns.sql
+++ b/src/dbdiff/templates/table_columns.sql
@@ -1,5 +1,13 @@
+{% if dialect == "vertica" -%}
 select column_name, data_type
   from columns
  where lower(table_schema) = lower('{{ schema_name }}')
        and lower(table_name) = lower('{{ table_name }}')
  order by ordinal_position
+{%- else -%}
+select column_name, data_type
+  from information_schema.columns
+ where lower(table_schema) = lower('{{ schema_name }}')
+       and lower(table_name) = lower('{{ table_name }}')
+ order by ordinal_position
+{%- endif %}

--- a/src/dbdiff/templates/table_exists.sql
+++ b/src/dbdiff/templates/table_exists.sql
@@ -1,4 +1,11 @@
+{% if dialect == "vertica" -%}
 select COUNT(*)
   from tables
  where table_schema = '{{ schema_name }}'
        and table_name = '{{ table_name }}'
+{%- else -%}
+select COUNT(*)
+  from information_schema.tables
+ where lower(table_schema) = lower('{{ schema_name }}')
+       and lower(table_name) = lower('{{ table_name }}')
+{%- endif %}

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -1,0 +1,461 @@
+"""Integration tests using DuckDB as the backend.
+
+These tests mirror the Vertica integration tests but run entirely in-process
+using DuckDB, requiring no external database server.
+
+Run with: pytest tests/test_duckdb.py -m duckdb_integration
+"""
+
+import logging
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from dbdiff.duckdb_backend import (
+    DuckDBCursorWrapper,
+    get_column_info,
+    get_column_info_lookup,
+    get_duckdb_cur,
+    get_table_exists,
+    implicit_dtype_comparison,
+)
+from dbdiff.main import (
+    check_primary_key,
+    create_diff_table,
+    create_joined_table,
+    get_all_col_info,
+    get_column_diffs,
+    get_column_diffs_from_joined,
+    get_diff_columns,
+    get_diff_rows,
+    get_diff_rows_from_joined,
+    get_unmatched_rows,
+    get_unmatched_rows_straight,
+    insert_diff_table,
+    select_distinct_rows,
+    set_dialect,
+)
+
+pytestmark = pytest.mark.duckdb_integration
+
+logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
+
+VALID_COL = {"comparable": True, "exclude": False}
+INT_DTYPES = {d: "INTEGER" for d in {"x_dtype", "y_dtype"}}
+VARCHAR_DTYPES = {d: "VARCHAR" for d in {"x_dtype", "y_dtype"}}
+DATE_DTYPES = {d: "DATE" for d in {"x_dtype", "y_dtype"}}
+COMPARE_COLS = pd.DataFrame(
+    {
+        "data1": {**INT_DTYPES, **VALID_COL},
+        "data2": {**INT_DTYPES, **VALID_COL},
+        "data3": {**DATE_DTYPES, **VALID_COL},
+        "data4": {**VARCHAR_DTYPES, **VALID_COL},
+    }
+).transpose()
+JOIN_COLS = pd.DataFrame(
+    {"join1": {**VARCHAR_DTYPES, **VALID_COL}, "join2": {**VARCHAR_DTYPES, **VALID_COL}}
+).transpose()
+
+
+@pytest.fixture(scope="session")
+def cur():
+    """Create a DuckDB in-memory cursor for the test session."""
+    set_dialect("duckdb")
+    with get_duckdb_cur() as c:
+        yield c
+
+
+def create_schema(cur):
+    cur.execute("CREATE SCHEMA IF NOT EXISTS dbdiff;")
+
+
+def create_x_table(cur):
+    cur.execute(
+        "CREATE TABLE dbdiff.x_table ("
+        " join1 VARCHAR, join2 VARCHAR, missingx INTEGER, missingx2 INTEGER,"
+        " dtypemiss INTEGER, data1 INTEGER, data2 INTEGER, data3 DATE, data4 VARCHAR);"
+    )
+    cur.execute(
+        "INSERT INTO dbdiff.x_table VALUES"
+        " ('match1', 'matchdup21', 0, 0, 0, 0, 0, '2017-10-11', ''),"
+        " ('match1', 'match22', 0, 0, 0, 0, 0, '2017-10-11', 'a'),"
+        " ('match1', 'match23', 0, 0, 0, 1, 1, '2017-10-11', ''),"
+        " ('match1', 'missx21', null, null, null, null, null, null, ''),"
+        " ('match1', 'missx22', null, null, null, null, null, null, ''),"
+        " ('missx11', null, null, null, null, null, null, null, ''),"
+        " ('missx12', null, null, null, null, null, null, null, ''),"
+        " (null, null, null, null, null, null, null, null, '');"
+    )
+
+
+def create_y_table(cur, case_off: bool = False):
+    cur.execute(
+        "CREATE TABLE dbdiff.y_table ("
+        " join1 VARCHAR, join2 VARCHAR, missingy INTEGER,"
+        " dtypemiss DATE, data1 INTEGER, data2 INTEGER, data3 DATE, data4 VARCHAR);"
+    )
+    data4_val = "A" if case_off else "a"
+    cur.execute(
+        "INSERT INTO dbdiff.y_table VALUES"
+        " ('match1', 'matchdup21', 0, '2019-04-22', 0, 0, '2017-10-11', ''),"
+        " ('match1', 'matchdup21', 0, '2019-04-22', 0, 0, '2017-10-11', ''),"
+        f" ('match1', 'match22', 0, '2019-04-22', 0, 1, '2017-10-12', '{data4_val}'),"
+        " ('match1', 'match23', 0, '2019-04-22', 0, 0, '2017-10-13', ''),"
+        " ('match1', 'missy21', 0, '2019-04-22', 0, 0, null, ''),"
+        " ('missy11', null, 0, '2019-04-22', 0, 0, null, '');"
+    )
+
+
+def drop_schema(cur):
+    cur.execute("DROP SCHEMA IF EXISTS dbdiff CASCADE;")
+
+
+def test_drop_data_start(cur):
+    drop_schema(cur)
+
+
+def test_create_data(cur):
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+
+def test_get_column_info(cur):
+    column_info = get_column_info(cur, "dbdiff", "x_table")
+    assert isinstance(column_info, pd.DataFrame)
+    assert "column_name" in column_info.columns
+    assert "data_type" in column_info.columns
+
+
+def test_get_column_info_lookup(cur):
+    column_info_lookup = get_column_info_lookup(cur, "dbdiff", "x_table")
+    assert "data1" in column_info_lookup
+    assert len(column_info_lookup) == 9
+
+
+def test_get_table_exists(cur):
+    assert get_table_exists(cur, "dbdiff", "x_table")
+    assert get_table_exists(cur, "dbdiff", "y_table")
+    assert not get_table_exists(cur, "dbdiff", "z_table")
+
+
+def test_implicit_dtype_comparison():
+    assert implicit_dtype_comparison("INTEGER", "FLOAT")
+    assert implicit_dtype_comparison("VARCHAR", "VARCHAR")
+    assert not implicit_dtype_comparison("INTEGER", "DATE")
+
+
+def test_check_primary_key(cur):
+    assert check_primary_key(cur, "dbdiff", "x_table", ["join1", "join2"]) == 0
+    assert check_primary_key(cur, "dbdiff", "x_table", ["join1"]) == 4
+
+
+def test_select_distinct_rows(cur):
+    x_table_rows = 8
+    x_table_columns = 9
+    new_table_schema, new_table_name = select_distinct_rows(
+        cur, "dbdiff", "x_table", ["join1"]
+    )
+    assert get_table_exists(cur, new_table_schema, "x_table_dedup")
+    assert get_table_exists(cur, new_table_schema, "x_table_dup")
+    cur.execute(f"SELECT * FROM {new_table_schema}.{new_table_name}")
+    dedup = pd.DataFrame(cur.fetchall())
+    assert dedup.shape[0] == 3
+    assert dedup.shape[1] == x_table_columns
+    cur.execute(f"SELECT * FROM {new_table_schema}.x_table_dup")
+    dup = pd.DataFrame(cur.fetchall())
+    assert dup.shape[0] == (x_table_rows - dedup.shape[0])
+    assert dup.shape[1] == (x_table_columns + 1)
+
+
+def test_create_joined_table(cur):
+    joined_row_count = create_joined_table(
+        cur,
+        x_schema="dbdiff",
+        y_schema="dbdiff",
+        x_table="x_table",
+        y_table="y_table",
+        join_cols=["join1", "join2"],
+        compare_cols=pd.concat([COMPARE_COLS, JOIN_COLS]),
+        joined_schema="dbdiff",
+        joined_table="x_table_JOINED",
+    )
+    assert get_table_exists(cur, "dbdiff", "x_table_JOINED")
+    cur.execute("SELECT * FROM dbdiff.x_table_JOINED")
+    df = pd.DataFrame(cur.fetchall())
+    assert df.shape[0] == 4
+    assert df.shape[1] == ((COMPARE_COLS.shape[0] * 2) + JOIN_COLS.shape[0])
+
+
+def test_get_unmatched_rows_straight(cur):
+    join_cols = ["join1", "join2"]
+    y_minus_x = [2, 1]
+    x_minus_y = [3, 2]
+    results = get_unmatched_rows_straight(
+        cur, "dbdiff", "dbdiff", "x_table", "y_table", join_cols, 100
+    )
+    expected_results = {
+        "x": {"count": sum(x_minus_y), "sample_shape": (sum(x_minus_y), len(join_cols))},
+        "y": {"count": sum(y_minus_x), "sample_shape": (sum(y_minus_x), len(join_cols))},
+    }
+    assert results["x"]["count"] == expected_results["x"]["count"]
+    assert results["x"]["sample"].shape[0] == expected_results["x"]["sample_shape"][0]
+    assert results["x"]["sample"].shape[1] == expected_results["x"]["sample_shape"][1]
+    assert results["y"]["count"] == expected_results["y"]["count"]
+    assert results["y"]["sample"].shape[0] == expected_results["y"]["sample_shape"][0]
+    assert results["y"]["sample"].shape[1] == expected_results["y"]["sample_shape"][1]
+
+
+def test_get_unmatched_rows(cur):
+    join_cols = ["join1", "join2"]
+    y_minus_x = [2, 1]
+    x_minus_y = [3, 2]
+    results = get_unmatched_rows(
+        cur, "dbdiff", "dbdiff", "x_table", "y_table", join_cols, 100
+    )
+    expected_results = {
+        j: {
+            side: {"count": d[i], "sample_shape": (d[i], i + 1)}
+            for side, d in {"x": x_minus_y, "y": y_minus_x}.items()
+        }
+        for i, j in enumerate(join_cols)
+    }
+    for col, expected in expected_results.items():
+        for side, expected_info in expected.items():
+            assert results[col][side]["count"] == expected_info["count"]
+            for i in {0, 1}:
+                assert (
+                    results[col][side]["sample"].shape[i]
+                    == expected_info["sample_shape"][i]
+                )
+
+
+def test_get_column_diffs_from_joined(cur):
+    """Test getting column diffs directly from the joined table (no diff table)."""
+    join_cols = ["join1", "join2"]
+
+    all_col_info_df = pd.concat([COMPARE_COLS, JOIN_COLS])
+    comparable_filter = (
+        ~all_col_info_df.exclude
+        & all_col_info_df.comparable
+        & ~all_col_info_df.x_dtype.isnull()
+        & ~all_col_info_df.y_dtype.isnull()
+    )
+
+    grouped_column_diffs = get_column_diffs_from_joined(
+        cur=cur,
+        output_schema="dbdiff",
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        join_cols=join_cols,
+        max_rows_column=100,
+        all_col_info_df=all_col_info_df,
+        comparable_filter=comparable_filter,
+        hierarchical=False,
+    )
+    # data1 has 1 diff, data2 has 2 diffs, data3 has 2 diffs
+    assert len(grouped_column_diffs) > 0
+    for col_name, info in grouped_column_diffs.items():
+        assert "count" in info
+        assert info["count"] > 0
+        assert "df" in info
+        assert "df_raw" in info
+
+
+def test_get_diff_rows_from_joined(cur):
+    """Test getting diff row summary from joined table."""
+    join_cols = ["join1", "join2"]
+
+    all_col_info_df = pd.concat([COMPARE_COLS, JOIN_COLS])
+    comparable_filter = (
+        ~all_col_info_df.exclude
+        & all_col_info_df.comparable
+        & ~all_col_info_df.x_dtype.isnull()
+        & ~all_col_info_df.y_dtype.isnull()
+    )
+
+    grouped_column_diffs = get_column_diffs_from_joined(
+        cur=cur,
+        output_schema="dbdiff",
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        join_cols=join_cols,
+        max_rows_column=100,
+        all_col_info_df=all_col_info_df,
+        comparable_filter=comparable_filter,
+        hierarchical=False,
+    )
+
+    diff_summary = get_diff_rows_from_joined(
+        cur=cur,
+        grouped_column_diffs=grouped_column_diffs,
+        output_schema="dbdiff",
+        x_table="x_table",
+        join_cols=join_cols,
+        max_rows_all=100,
+        skip_row_total=False,
+    )
+    assert "count" in diff_summary
+    assert "total_count" in diff_summary
+    assert diff_summary["total_count"] > 0
+
+
+def test_main_end_to_end(cur):
+    """Full end-to-end test using the main() function from cli.py."""
+    from dbdiff.cli import main
+    from dbdiff.report import html_report
+
+    # Recreate tables to ensure clean state
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=False,
+        hierarchical_join=False,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=False,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    assert "x_schema" in all_info
+    assert "y_schema" in all_info
+    assert "column_info" in all_info
+    assert "diff_summary" in all_info
+    # After dedup of y_table (which has duplicate matchdup21 rows),
+    # only match22 and match23 remain as inner join matches
+    assert all_info["total_row_count"] == 2
+
+    # Generate HTML report
+    report = html_report(**all_info)
+    assert len(report) > 0
+    assert "x_table" in report
+
+
+def test_main_with_hierarchical_join(cur):
+    """Test with hierarchical join enabled."""
+    from dbdiff.cli import main
+
+    # Recreate tables since previous test may have modified state
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=False,
+        hierarchical_join=True,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=False,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    assert "hierarchical_join_info" in all_info
+    assert len(all_info["hierarchical_join_info"]) > 0
+
+
+def test_main_with_use_diff_table(cur):
+    """Test with use_diff_table enabled."""
+    from dbdiff.cli import main
+
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=False,
+        hierarchical_join=False,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=True,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    assert "diff_summary" in all_info
+    assert all_info["diff_summary"]["total_count"] > 0
+
+
+def test_main_with_drop_output_tables(cur):
+    """Test with drop_output_tables enabled."""
+    from dbdiff.cli import main
+
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=True,
+        hierarchical_join=False,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=False,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    # After dedup of y_table (which has duplicate matchdup21 rows),
+    # only match22 and match23 remain as inner join matches
+    assert all_info["total_row_count"] == 2
+    # Joined table should have been dropped
+    assert not get_table_exists(cur, "dbdiff", "x_table_JOINED")
+
+
+def test_drop_data_end(cur):
+    drop_schema(cur)


### PR DESCRIPTION
Implements issue #11 — adds DuckDB as a dialect target, enabling dbdiff
to run entirely in-process without requiring a database server.

Changes:
- Add duckdb_backend.py with cursor wrapper (dict-cursor compatible with
  Vertica's interface), connection manager, and helper functions
- Update SQL templates for DuckDB compatibility:
  - table_columns.sql / table_exists.sql: use information_schema
  - create_dedup.sql / create_dup.sql: CREATE TABLE AS instead of SELECT INTO
  - create_temp_table.sql: CREATE TEMP TABLE (no LOCAL/ON COMMIT)
- Make main.py dialect-aware: null-safe equality helper, backend dispatch
  for column info and dtype comparison
- Update cli.py to select backend based on --dialect flag
- Add 18 DuckDB integration tests covering all core comparison operations
- Add duckdb as optional dependency and dev dependency

All 114 existing tests continue to pass (17 Vertica tests skipped as expected).

https://claude.ai/code/session_01MQTPWhFJu2m63FhXWPbdR2