### PR TITLE
feat: add PostgreSQL, DuckDB, and SQLite dialect targets

### DIFF
--- a/src/dbdiff/cli.py
+++ b/src/dbdiff/cli.py
@@ -155,7 +155,8 @@ def get_summary_from_all_info(d: dict) -> dict:
 @click.option(
     "--dialect",
     default="vertica",
-    help="SQL dialect to use for generated SQL (default: vertica).",
+    type=click.Choice(["vertica", "postgres", "duckdb", "sqlite"], case_sensitive=False),
+    help="SQL dialect to use for generated SQL.",
     show_default=True,
 )
 @click.version_option(__version__)

--- a/src/dbdiff/templates/all_keys_count.sql
+++ b/src/dbdiff/templates/all_keys_count.sql
@@ -4,6 +4,8 @@
            ON {% for col in join_cols -%}
            {%- if dialect == "vertica" -%}
            x.{{ col }} <=> y.{{ col }}
+           {%- elif dialect == "sqlite" -%}
+           x.{{ col }} IS y.{{ col }}
            {%- else -%}
            x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
            {%- endif -%}

--- a/src/dbdiff/templates/all_keys_sample.sql
+++ b/src/dbdiff/templates/all_keys_sample.sql
@@ -6,6 +6,8 @@ SELECT {% for col in join_cols -%}
                    ON {% for col in join_cols -%}
                    {%- if dialect == "vertica" -%}
                    x.{{ col }} <=> y.{{ col }}
+                   {%- elif dialect == "sqlite" -%}
+                   x.{{ col }} IS y.{{ col }}
                    {%- else -%}
                    x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
                    {%- endif -%}

--- a/src/dbdiff/templates/create_joined_table_from_selectinto.sql
+++ b/src/dbdiff/templates/create_joined_table_from_selectinto.sql
@@ -19,13 +19,24 @@ CREATE TABLE {{ joined_schema }}.{{ joined_table }} AS
             {% if row.name in join_cols -%}
             COALESCE(x.{{ row.name }}, y.{{ row.name }}) AS {{ row.name -}}
             {% else -%}
+            {%- if dialect == "sqlite" -%}
             CAST(x.{{ row.name }} AS {{ row.x_dtype }}) AS x_{{ row.name }},
             CAST(y.{{ row.name }} AS {{ row.x_dtype }}) AS y_{{ row.name -}}
+            {%- else -%}
+            x.{{ row.name }}::{{ row.x_dtype }} AS x_{{ row.name }},
+            y.{{ row.name }}::{{ row.x_dtype }} AS y_{{ row.name -}}
+            {%- endif -%}
             {%- endif -%}
             {%- if not loop.last %},{% endif -%}
             {%- endfor %}
        FROM {{ x_schema }}.{{ x_table }} AS x
  INNER JOIN {{ y_schema }}.{{ y_table }} AS y
-            ON {% for col in join_cols %}x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}{% if not loop.last %} AND {% endif %}
+            ON {% for col in join_cols -%}
+            {%- if dialect == "sqlite" -%}
+            x.{{ col }} IS y.{{ col }}
+            {%- else -%}
+            x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
+            {%- endif -%}
+            {%- if not loop.last %} AND {% endif %}
             {% endfor %}
 {%- endif %}

--- a/src/dbdiff/templates/insert_joined_table.sql
+++ b/src/dbdiff/templates/insert_joined_table.sql
@@ -14,7 +14,7 @@ INSERT INTO {{ joined_schema }}.{{ joined_table }} (
             {%- if row.name in join_cols -%}
             COALESCE(x.{{ row.name }}, y.{{ row.name }}) AS {{ row.name -}}
             {%- else -%}
-            {%- if dialect == "vertica" -%}
+            {%- if dialect in ("vertica", "postgres", "duckdb") -%}
             x.{{ row.name }}::{{ row.x_dtype }} AS x_{{ row.name }},
             y.{{ row.name }}::{{ row.x_dtype }} AS y_{{ row.name -}}
             {%- else -%}
@@ -29,6 +29,8 @@ INSERT INTO {{ joined_schema }}.{{ joined_table }} (
             ON {% for col in join_cols -%}
             {%- if dialect == "vertica" -%}
             x.{{ col }} <=> y.{{ col }}
+            {%- elif dialect == "sqlite" -%}
+            x.{{ col }} IS y.{{ col }}
             {%- else -%}
             x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
             {%- endif -%}

--- a/src/dbdiff/templates/joined_column.sql
+++ b/src/dbdiff/templates/joined_column.sql
@@ -4,6 +4,8 @@
     FROM {{ joined_schema }}.{{ joined_table }}
    WHERE {% if dialect == "vertica" -%}
    (x_{{ column }} <=> y_{{ column }}) IS FALSE
+   {%- elif dialect == "sqlite" -%}
+   (x_{{ column }} IS NOT y_{{ column }})
    {%- else -%}
    (x_{{ column }} IS DISTINCT FROM y_{{ column }})
    {%- endif %}

--- a/src/dbdiff/templates/joined_column_hier.sql
+++ b/src/dbdiff/templates/joined_column_hier.sql
@@ -6,6 +6,8 @@
              FROM {{ joined_schema }}.{{ joined_table }}
              WHERE {% if dialect == "vertica" -%}
              (x_{{ column }} <=> y_{{ column }}) IS FALSE
+             {%- elif dialect == "sqlite" -%}
+             (x_{{ column }} IS NOT y_{{ column }})
              {%- else -%}
              (x_{{ column }} IS DISTINCT FROM y_{{ column }})
              {%- endif %}

--- a/src/dbdiff/templates/joined_column_raw.sql
+++ b/src/dbdiff/templates/joined_column_raw.sql
@@ -4,6 +4,8 @@
       FROM {{ joined_schema }}.{{ joined_table }}
      WHERE {% if dialect == "vertica" -%}
      (x_{{ column }} <=> y_{{ column }}) IS FALSE
+     {%- elif dialect == "sqlite" -%}
+     (x_{{ column }} IS NOT y_{{ column }})
      {%- else -%}
      (x_{{ column }} IS DISTINCT FROM y_{{ column }})
      {%- endif %}

--- a/src/dbdiff/templates/joined_count.sql
+++ b/src/dbdiff/templates/joined_count.sql
@@ -2,6 +2,8 @@ SELECT COUNT(*)
   FROM {{ joined_schema }}.{{ joined_table }}
  WHERE {% if dialect == "vertica" -%}
  (x_{{ column }} <=> y_{{ column }}) IS FALSE
+ {%- elif dialect == "sqlite" -%}
+ (x_{{ column }} IS NOT y_{{ column }})
  {%- else -%}
  (x_{{ column }} IS DISTINCT FROM y_{{ column }})
  {%- endif %}

--- a/src/dbdiff/templates/joined_rows_count.sql
+++ b/src/dbdiff/templates/joined_rows_count.sql
@@ -3,6 +3,8 @@ SELECT COUNT(*)
  WHERE {% for column in columns -%}
  {%- if dialect == "vertica" -%}
  ((x_{{ column }} <=> y_{{ column }}) IS FALSE)
+ {%- elif dialect == "sqlite" -%}
+ (x_{{ column }} IS NOT y_{{ column }})
  {%- else -%}
  (x_{{ column }} IS DISTINCT FROM y_{{ column }})
  {%- endif -%}

--- a/src/dbdiff/templates/joined_rows_sample.sql
+++ b/src/dbdiff/templates/joined_rows_sample.sql
@@ -3,6 +3,8 @@ SELECT joined.*
  WHERE {% for column in columns -%}
  {%- if dialect == "vertica" -%}
  ((x_{{ column }} <=> y_{{ column }}) IS FALSE)
+ {%- elif dialect == "sqlite" -%}
+ (x_{{ column }} IS NOT y_{{ column }})
  {%- else -%}
  (x_{{ column }} IS DISTINCT FROM y_{{ column }})
  {%- endif -%}

--- a/src/dbdiff/templates/sub_keys_base.sql
+++ b/src/dbdiff/templates/sub_keys_base.sql
@@ -12,6 +12,8 @@ INNER JOIN {{ y_schema }}.{{ y_table }} y
        {%- else -%}
        {%- if dialect == "vertica" -%}
        x.{{ col }} <=> y.{{ col }}
+       {%- elif dialect == "sqlite" -%}
+       x.{{ col }} IS y.{{ col }}
        {%- else -%}
        x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
        {%- endif -%}
@@ -45,6 +47,8 @@ INNER JOIN {{ x_schema }}.{{ x_table }} x
        {%- else -%}
        {%- if dialect == "vertica" -%}
        x.{{ col }} <=> y.{{ col }}
+       {%- elif dialect == "sqlite" -%}
+       x.{{ col }} IS y.{{ col }}
        {%- else -%}
        x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
        {%- endif -%}

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -9,12 +9,27 @@ from jinja2 import Environment, PackageLoader
 # and sqlglot doesn't have a specific Vertica dialect
 PARSE_DIALECT = "postgres"
 
+# Mapping from dbdiff dialect to sqlglot parse dialect
+DIALECT_TO_SQLGLOT = {
+    "vertica": "postgres",
+    "postgres": "postgres",
+    "duckdb": "duckdb",
+    "sqlite": "sqlite",
+}
+
 
 @pytest.fixture
 def jinja_env():
     """Create a Jinja2 environment for rendering templates."""
     env = Environment(loader=PackageLoader("dbdiff", "templates"))
     env.globals["dialect"] = "vertica"
+    return env
+
+
+def make_jinja_env(dialect):
+    """Create a Jinja2 environment for a specific dialect."""
+    env = Environment(loader=PackageLoader("dbdiff", "templates"))
+    env.globals["dialect"] = dialect
     return env
 
 
@@ -426,3 +441,219 @@ class TestSQLTemplateRendering:
             columns=["amount", "name"],
         )
         sqlglot.parse(sql, dialect=PARSE_DIALECT, error_level=sqlglot.ErrorLevel.RAISE)
+
+
+@pytest.fixture(params=["postgres", "duckdb", "sqlite"])
+def dialect_env(request):
+    """Parametrized fixture providing (jinja_env, sqlglot_dialect) for each target dialect."""
+    dialect = request.param
+    env = make_jinja_env(dialect)
+    return env, DIALECT_TO_SQLGLOT[dialect]
+
+
+@pytest.fixture
+def dialect_compare_cols():
+    """Sample dataframe for compare_cols with multiple columns."""
+    return pd.DataFrame(
+        {
+            "x_dtype": ["INTEGER", "VARCHAR(100)", "FLOAT", "DATE"],
+            "y_dtype": ["INTEGER", "VARCHAR(100)", "FLOAT", "DATE"],
+        },
+        index=["id", "name", "amount", "created_at"],
+    )
+
+
+@pytest.fixture
+def dialect_join_cols():
+    """Sample join column list."""
+    return ["id"]
+
+
+class TestDialectTemplateRendering:
+    """Test that dialect-specific SQL templates render and parse correctly for postgres, duckdb, and sqlite."""
+
+    def test_create_joined_table(self, dialect_env, dialect_compare_cols, dialect_join_cols):
+        """Test create_joined_table.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("create_joined_table.sql")
+        sql = template.render(
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            compare_cols=dialect_compare_cols,
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_create_joined_table_from_selectinto(
+        self, dialect_env, dialect_compare_cols, dialect_join_cols
+    ):
+        """Test create_joined_table_from_selectinto.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("create_joined_table_from_selectinto.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            compare_cols=dialect_compare_cols,
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_insert_joined_table(self, dialect_env, dialect_compare_cols, dialect_join_cols):
+        """Test insert_joined_table.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("insert_joined_table.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            compare_cols=dialect_compare_cols,
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_all_keys_count(self, dialect_env, dialect_join_cols):
+        """Test all_keys_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("all_keys_count.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=dialect_join_cols,
+            x=True,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_all_keys_sample(self, dialect_env, dialect_join_cols):
+        """Test all_keys_sample.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("all_keys_sample.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=dialect_join_cols,
+            x=True,
+            max_rows_column=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_sub_keys_count(self, dialect_env):
+        """Test sub_keys_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("sub_keys_count.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=["id", "name"],
+            x=True,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_sub_keys_sample(self, dialect_env):
+        """Test sub_keys_sample.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("sub_keys_sample.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=["id", "name"],
+            x=True,
+            max_rows_column=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_sub_keys_grouped(self, dialect_env):
+        """Test sub_keys_grouped.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("sub_keys_grouped.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=["id", "name"],
+            x=True,
+            max_rows_column=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_count(self, dialect_env):
+        """Test joined_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_count.sql")
+        sql = template.render(
+            column="amount", joined_schema="output_schema", joined_table="joined_table"
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_column(self, dialect_env):
+        """Test joined_column.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_column.sql")
+        sql = template.render(
+            column="amount", joined_schema="output_schema", joined_table="joined_table"
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_column_raw(self, dialect_env, dialect_join_cols):
+        """Test joined_column_raw.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_column_raw.sql")
+        sql = template.render(
+            column="amount",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_column_hier(self, dialect_env, dialect_join_cols):
+        """Test joined_column_hier.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_column_hier.sql")
+        sql = template.render(
+            column="amount",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            join_cols=dialect_join_cols,
+            schema="x_schema",
+            table="x_table",
+            limit=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_rows_count(self, dialect_env):
+        """Test joined_rows_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_rows_count.sql")
+        sql = template.render(
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            columns=["amount", "name"],
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_rows_sample(self, dialect_env):
+        """Test joined_rows_sample.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_rows_sample.sql")
+        sql = template.render(
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            columns=["amount", "name"],
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)


### PR DESCRIPTION
Add support for three new SQL dialects in the template rendering layer:

- PostgreSQL (#9): uses IS NOT DISTINCT FROM and ::dtype casting
- DuckDB (#11): uses IS NOT DISTINCT FROM and ::dtype casting
- SQLite (#10): uses IS/IS NOT operators and CAST() syntax

Updates 12 SQL templates with dialect-specific conditionals for null-safe
equality/inequality operators and type casting syntax. Adds click.Choice
validation for the --dialect CLI option. Includes parametrized sqlglot
syntax tests for all three new dialects (42 new test cases).

Closes #9, closes #10, closes #11

https://claude.ai/code/session_01EymYNdFZKdJq3s7FHhixoH