### PR TITLE
feat: add multi-dialect support (PostgreSQL, DuckDB, SQLite)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,16 @@ Issues = "https://github.com/andyreagan/dbdiff/issues"
 [project.scripts]
 dbdiff = "dbdiff.cli:cli"
 
+[project.optional-dependencies]
+duckdb = ["duckdb"]
+
 [dependency-groups]
 dev = [
     "pytest",
     "pytest-cov",
     "click",
     "sqlglot",
+    "duckdb",
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -70,6 +74,7 @@ addopts = [
 ]
 markers = [
     "integration: requires a running Vertica instance",
+    "duckdb_integration: integration tests using DuckDB (no external server required)",
 ]
 testpaths = ["tests"]
 

--- a/src/dbdiff/cli.py
+++ b/src/dbdiff/cli.py
@@ -155,7 +155,8 @@ def get_summary_from_all_info(d: dict) -> dict:
 @click.option(
     "--dialect",
     default="vertica",
-    help="SQL dialect to use for generated SQL (default: vertica).",
+    type=click.Choice(["vertica", "postgres", "duckdb", "sqlite"], case_sensitive=False),
+    help="SQL dialect to use for generated SQL.",
     show_default=True,
 )
 @click.version_option(__version__)
@@ -357,14 +358,18 @@ def main(
         hierarchical_join_info = {}
 
     # create sub-tables to allow a comparison:
+    # Temp tables with v_temp_schema are Vertica-specific; skip for other dialects
+    use_vertica_temp = dialect == "vertica"
     if x != 0:
         LOGGER.info("X table was not unique on join keys, creating _dedup and _dup versions.")
-        schema, x_table = select_distinct_rows(
+        x_schema, x_table = select_distinct_rows(
             cur,
             x_schema,
             x_table,
             join_cols,
-            use_temp_tables=(drop_output_tables or x_schema == "v_temp_schema"),
+            use_temp_tables=(
+                use_vertica_temp and (drop_output_tables or x_schema == "v_temp_schema")
+            ),
         )
     if y != 0:
         LOGGER.info("Y table was not unique on join keys, creating _dedup and _dup versions.")
@@ -373,7 +378,9 @@ def main(
             y_schema,
             y_table,
             join_cols,
-            use_temp_tables=(drop_output_tables or y_schema == "v_temp_schema"),
+            use_temp_tables=(
+                use_vertica_temp and (drop_output_tables or y_schema == "v_temp_schema")
+            ),
         )
 
     LOGGER.info("Getting rows that did not match (not in joined table) after deduping.")

--- a/src/dbdiff/duckdb_backend.py
+++ b/src/dbdiff/duckdb_backend.py
@@ -1,0 +1,135 @@
+"""DuckDB backend for dbdiff.
+
+Provides a cursor wrapper and helper functions that match the interface
+used by the Vertica backend, allowing dbdiff to run entirely in-process
+against DuckDB.
+"""
+
+import logging
+from contextlib import contextmanager
+
+import duckdb
+import pandas as pd
+from jinja2 import Environment, PackageLoader
+
+JINJA_ENV = Environment(loader=PackageLoader("dbdiff", "templates"))
+LOGGER = logging.getLogger(__name__)
+
+
+class DuckDBCursorWrapper:
+    """Wraps a duckdb.DuckDBPyConnection to provide a dict-cursor interface
+    compatible with vertica_python's dict cursor."""
+
+    def __init__(self, conn: duckdb.DuckDBPyConnection):
+        self._conn = conn
+        self._description = None
+
+    def execute(self, sql: str) -> "DuckDBCursorWrapper":
+        sql_stripped = sql.strip().rstrip(";").strip()
+        # DuckDB auto-commits; skip explicit COMMIT statements
+        if sql_stripped.upper() == "COMMIT":
+            return self
+        self._conn.execute(sql)
+        self._description = self._conn.description
+        return self
+
+    def fetchall(self) -> list[dict]:
+        if self._description is None:
+            return []
+        columns = [self._normalize_col_name(desc[0]) for desc in self._description]
+        rows = self._conn.fetchall()
+        return [dict(zip(columns, row)) for row in rows]
+
+    @staticmethod
+    def _normalize_col_name(name: str) -> str:
+        """Normalize DuckDB column names to match Vertica conventions.
+
+        DuckDB uses 'count_star()' for COUNT(*), while Vertica uses 'COUNT'.
+        """
+        if name == "count_star()":
+            return "COUNT"
+        return name
+
+    @property
+    def description(self):
+        return self._description
+
+
+@contextmanager
+def get_duckdb_cur(database: str = ":memory:"):
+    """Context manager that yields a DuckDB cursor wrapper.
+
+    Args:
+        database: Path to DuckDB database file, or ":memory:" for in-memory.
+    """
+    conn = duckdb.connect(database)
+    try:
+        yield DuckDBCursorWrapper(conn)
+    finally:
+        conn.close()
+
+
+def get_column_info(cur: DuckDBCursorWrapper, schema_name: str, table_name: str) -> pd.DataFrame:
+    """Get column info from DuckDB's information_schema."""
+    column_template = JINJA_ENV.get_template("table_columns.sql")
+    cur.execute(
+        column_template.render(schema_name=schema_name, table_name=table_name, dialect="duckdb")
+    )
+    df = pd.DataFrame(cur.fetchall())
+    if df.shape[0] == 0:
+        raise RuntimeError(f"{schema_name}.{table_name} has no columns.")
+    return df
+
+
+def get_column_info_lookup(cur: DuckDBCursorWrapper, schema_name: str, table_name: str) -> dict:
+    x_table_info = get_column_info(cur, schema_name, table_name)
+    LOGGER.info(
+        "Column info DuckDB for "
+        + schema_name
+        + "."
+        + table_name
+        + ":\n"
+        + x_table_info.head().to_string()
+        + "\n..."
+    )
+    x_table_info["column_name"] = x_table_info["column_name"].str.lower()
+    return {r.column_name: r.data_type for i, r in x_table_info.iterrows()}
+
+
+def get_table_exists(cur: DuckDBCursorWrapper, schema_name: str, table_name: str) -> bool:
+    table_exists_template = JINJA_ENV.get_template("table_exists.sql")
+    cur.execute(
+        table_exists_template.render(
+            schema_name=schema_name, table_name=table_name, dialect="duckdb"
+        )
+    )
+    result = cur.fetchall()
+    return result[0]["COUNT"] == 1
+
+
+def implicit_dtype_comparison(x_dtype: str, y_dtype: str) -> bool:
+    """Can x_dtype be implicitly converted to y_dtype in DuckDB?
+
+    DuckDB is generally more permissive with implicit casts than Vertica,
+    but we use similar rules for consistency.
+    """
+    source = x_dtype.upper()
+    target = y_dtype.upper()
+    if "INT" in source:
+        return (
+            "BOOL" in target
+            or "NUMERIC" in target
+            or "FLOAT" in target
+            or "INT" in target
+            or "BIGINT" in target
+        )
+    elif "NUMERIC" in source or "DECIMAL" in source:
+        return "FLOAT" in target or "NUMERIC" in target or "DECIMAL" in target
+    elif "CHAR" in source or "VARCHAR" in source or "TEXT" in source:
+        return "CHAR" in target or "VARCHAR" in target or "TEXT" in target or "FLOAT" in target
+    elif "DATE" in source and "DATE" in target:
+        return True
+    elif "TIMESTAMP" in source and "TIMESTAMP" in target:
+        return True
+    else:
+        return source == target

--- a/src/dbdiff/main.py
+++ b/src/dbdiff/main.py
@@ -5,9 +5,31 @@ from typing import Any
 
 import pandas as pd
 from jinja2 import Environment, PackageLoader
-from vertica_python.vertica.cursor import Cursor
 
-from dbdiff.vertica import get_column_info_lookup, implicit_dtype_comparison
+from dbdiff.vertica import get_column_info_lookup as vertica_get_column_info_lookup
+from dbdiff.vertica import implicit_dtype_comparison as vertica_implicit_dtype_comparison
+
+# Current dialect, set by set_dialect()
+_current_dialect = "vertica"
+
+
+def _get_column_info_lookup(cur, schema_name, table_name):
+    if _current_dialect == "duckdb":
+        from dbdiff.duckdb_backend import get_column_info_lookup as duckdb_get_column_info_lookup
+
+        return duckdb_get_column_info_lookup(cur, schema_name, table_name)
+    return vertica_get_column_info_lookup(cur, schema_name, table_name)
+
+
+def _implicit_dtype_comparison(x_dtype, y_dtype):
+    if _current_dialect == "duckdb":
+        from dbdiff.duckdb_backend import (
+            implicit_dtype_comparison as duckdb_implicit_dtype_comparison,
+        )
+
+        return duckdb_implicit_dtype_comparison(x_dtype, y_dtype)
+    return vertica_implicit_dtype_comparison(x_dtype, y_dtype)
+
 
 JINJA_ENV = Environment(loader=PackageLoader("dbdiff", "templates"))
 LOGGER = logging.getLogger(__name__)
@@ -15,7 +37,16 @@ LOGGER = logging.getLogger(__name__)
 
 def set_dialect(dialect: str = "vertica") -> None:
     """Set the SQL dialect for template rendering."""
+    global _current_dialect
+    _current_dialect = dialect
     JINJA_ENV.globals["dialect"] = dialect
+
+
+def _null_safe_eq(left_alias: str, col: str, right_alias: str) -> str:
+    """Return a null-safe equality expression for the current dialect."""
+    if _current_dialect == "vertica":
+        return f"{left_alias}.{col} <=> {right_alias}.{col}"
+    return f"{left_alias}.{col} IS NOT DISTINCT FROM {right_alias}.{col}"
 
 
 def is_numeric_like(dtype: str):
@@ -28,7 +59,7 @@ def is_date_like(dtype: str):
     return "date" in dtype_l
 
 
-def check_primary_key(cur: Cursor, schema: str, table: str, join_cols: list) -> int:
+def check_primary_key(cur, schema: str, table: str, join_cols: list) -> int:
     """Given a list of columns return the # of records for which they are NOT
     a primary key."""
 
@@ -47,7 +78,7 @@ def check_primary_key(cur: Cursor, schema: str, table: str, join_cols: list) -> 
 
 
 def get_all_col_info(
-    cur: Cursor,
+    cur,
     schema,
     x_table,
     y_schema,
@@ -57,14 +88,14 @@ def get_all_col_info(
     save_column_summary_format,
 ) -> pd.DataFrame:
     LOGGER.info("Getting column info for both tables.")
-    x_table_info_lookup = get_column_info_lookup(cur, schema, x_table)
-    y_table_info_lookup = get_column_info_lookup(cur, y_schema, y_table)
+    x_table_info_lookup = _get_column_info_lookup(cur, schema, x_table)
+    y_table_info_lookup = _get_column_info_lookup(cur, y_schema, y_table)
 
     def comparable_(x, y) -> bool:
         # this doesn't capture the case where they both could be converted to float to be compared (two hop conversions):
         if (x is None) or (y is None):
             return False
-        x_or_y = implicit_dtype_comparison(x, y) or implicit_dtype_comparison(y, x)
+        x_or_y = _implicit_dtype_comparison(x, y) or _implicit_dtype_comparison(y, x)
         return x_or_y
 
     all_keys = list(x_table_info_lookup.keys()) + list(y_table_info_lookup.keys())
@@ -108,7 +139,7 @@ def get_all_col_info(
 
 
 def select_distinct_rows(
-    cur: Cursor, schema: str, table: str, join_cols: list, use_temp_tables: bool = False
+    cur, schema: str, table: str, join_cols: list, use_temp_tables: bool = False
 ) -> tuple[str, str]:
     """Select only the rows that are distinct on join_cols.
     *Instead of deleting the rows, we'll select those without duplicates into a
@@ -121,12 +152,18 @@ def select_distinct_rows(
     )
     LOGGER.info(drop_q)
     cur.execute(drop_q)
+    if _current_dialect == "vertica":
+        join_expr = " AND ".join([_null_safe_eq("x", col, "y") for col in join_cols])
+    else:
+        join_expr = " AND ".join(
+            ["x.{0} IS NOT DISTINCT FROM y.{0}".format(col) for col in join_cols]
+        )
     q = JINJA_ENV.get_template("create_dedup.sql").render(
         schema_name=schema,
         table_name=table,
         table_name_dedup=(table + "_dedup"),
         group_cols=", ".join(join_cols),
-        join_cols=" AND ".join(["x.{0} <=> y.{0}".format(col) for col in join_cols]),
+        join_cols=join_expr,
         use_temp_table=use_temp_tables,
     )
     if use_temp_tables:
@@ -147,7 +184,7 @@ def select_distinct_rows(
         table_name=table,
         table_name_dup=(table + "_dup"),
         group_cols=", ".join(join_cols),
-        join_cols=" AND ".join(["x.{0} <=> y.{0}".format(col) for col in join_cols]),
+        join_cols=join_expr,
         use_temp_table=use_temp_tables,
     )
     if use_temp_tables:
@@ -159,10 +196,13 @@ def select_distinct_rows(
     LOGGER.info("COMMIT;")
     cur.execute("COMMIT;")
 
-    return (schema, "v_temp_schema")[use_temp_tables], f"{table}_dedup"
+    # For Vertica, temp tables go to v_temp_schema; for other dialects, use original schema
+    if use_temp_tables and _current_dialect == "vertica":
+        return "v_temp_schema", f"{table}_dedup"
+    return schema, f"{table}_dedup"
 
 
-def create_joined_table(cur: Cursor, create_insert=False, **kwargs):
+def create_joined_table(cur, create_insert=False, **kwargs):
     """
     Joins two tables x and y.
     :param cur: vertica python Cursor
@@ -203,7 +243,7 @@ def create_joined_table(cur: Cursor, create_insert=False, **kwargs):
 
 
 def get_unmatched_rows_straight(
-    cur: Cursor,
+    cur,
     x_schema: str,
     y_schema: str,
     x_table: str,
@@ -244,7 +284,7 @@ def get_unmatched_rows_straight(
 
 
 def get_unmatched_rows(
-    cur: Cursor,
+    cur,
     x_schema: str,
     y_schema: str,
     x_table: str,
@@ -332,7 +372,7 @@ def get_unmatched_rows(
 
 
 def create_diff_table(
-    cur: Cursor, schema: str, table: str, join_cols: list, all_col_info_df: pd.DataFrame
+    cur, schema: str, table: str, join_cols: list, all_col_info_df: pd.DataFrame
 ) -> str:
     drop_q = JINJA_ENV.get_template("table_drop.sql").render(schema_name=schema, table_name=table)
     # so simple that putting into a template would make this harder to follow...
@@ -350,13 +390,13 @@ def create_diff_table(
     return q
 
 
-def insert_diff_table(cur: Cursor, **kwargs) -> None:
+def insert_diff_table(cur, **kwargs) -> None:
     cur.execute(JINJA_ENV.get_template("insert_diff.sql").render(kwargs))
     cur.execute("COMMIT;")
 
 
 def get_diff_rows(
-    cur: Cursor,
+    cur,
     output_schema: str,
     x_table: str,
     join_cols: list,
@@ -390,7 +430,7 @@ def get_diff_rows(
         joined_table=(x_table + "_JOINED"),
         diff_table=(x_table + "_DIFF"),
         group_cols=", ".join(join_cols),
-        join_cols=" AND ".join(["x.{0} <=> joined.{0}".format(col) for col in join_cols]),
+        join_cols=" AND ".join([_null_safe_eq("x", col, "joined") for col in join_cols]),
     )
     LOGGER.info(q)
     cur.execute(q + " LIMIT " + str(max_rows_all))
@@ -405,7 +445,7 @@ def get_diff_rows(
 
 
 def get_diff_rows_from_joined(
-    cur: Cursor,
+    cur,
     grouped_column_diffs: dict,
     output_schema: str,
     x_table: str,
@@ -466,7 +506,7 @@ def get_diff_rows_from_joined(
     }
 
 
-def get_diff_columns(cur: Cursor, output_schema: str, x_table: str) -> pd.DataFrame:
+def get_diff_columns(cur, output_schema: str, x_table: str) -> pd.DataFrame:
     LOGGER.debug("Getting diff columns")
     # The # of columns has a hard limit (~1600 in Vertica?) so don't worry about
     # pulling the count first or limiting the results
@@ -479,7 +519,7 @@ def get_diff_columns(cur: Cursor, output_schema: str, x_table: str) -> pd.DataFr
 
 def get_column_diffs(
     diff_columns: pd.DataFrame,
-    cur: Cursor,
+    cur,
     output_schema: str,
     x_schema: str,
     x_table: str,
@@ -512,7 +552,7 @@ def get_column_diffs(
             diff_schema=output_schema,
             diff_table=(x_table + "_DIFF"),
             group_cols=", ".join(join_cols),
-            join_cols=" AND ".join(["diff.{0} <=> joined.{0}".format(col) for col in join_cols]),
+            join_cols=" AND ".join([_null_safe_eq("diff", col, "joined") for col in join_cols]),
         )
         info["q"] = q
         q_raw = JINJA_ENV.get_template("diff_column_raw.sql").render(
@@ -523,7 +563,7 @@ def get_column_diffs(
             diff_table=(x_table + "_DIFF"),
             join_cols=join_cols,
             join_cols_join=" AND ".join(
-                ["diff.{0} <=> joined.{0}".format(col) for col in join_cols]
+                [_null_safe_eq("diff", col, "joined") for col in join_cols]
             ),
         )
         info["q_raw"] = q_raw
@@ -560,9 +600,7 @@ def get_column_diffs(
                 diff_schema=output_schema,
                 diff_table=(x_table + "_DIFF"),
                 group_cols=", ".join(join_cols),
-                join_cols=" AND ".join(
-                    ["diff.{0} <=> joined.{0}".format(col) for col in join_cols]
-                ),
+                join_cols=" AND ".join([_null_safe_eq("diff", col, "joined") for col in join_cols]),
                 tiles=min({max({1, info["count"]}), 10}),
             )
             cur.execute(info["q_n"])
@@ -577,7 +615,7 @@ def get_column_diffs(
                 diff_table=(x_table + "_DIFF"),
                 join_cols=join_cols,
                 join_cols_join=" AND ".join(
-                    ["diff.{0} <=> joined.{0}".format(col) for col in join_cols]
+                    [_null_safe_eq("diff", col, "joined") for col in join_cols]
                 ),
             )
             cur.execute(info["q_n_sample"] + " LIMIT " + str(max_rows_column))
@@ -586,7 +624,7 @@ def get_column_diffs(
 
 
 def get_column_diffs_from_joined(
-    cur: Cursor,
+    cur,
     output_schema: str,
     x_schema: str,
     x_table: str,

--- a/src/dbdiff/templates/all_keys_count.sql
+++ b/src/dbdiff/templates/all_keys_count.sql
@@ -4,6 +4,8 @@
            ON {% for col in join_cols -%}
            {%- if dialect == "vertica" -%}
            x.{{ col }} <=> y.{{ col }}
+           {%- elif dialect == "sqlite" -%}
+           x.{{ col }} IS y.{{ col }}
            {%- else -%}
            x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
            {%- endif -%}

--- a/src/dbdiff/templates/all_keys_sample.sql
+++ b/src/dbdiff/templates/all_keys_sample.sql
@@ -6,6 +6,8 @@ SELECT {% for col in join_cols -%}
                    ON {% for col in join_cols -%}
                    {%- if dialect == "vertica" -%}
                    x.{{ col }} <=> y.{{ col }}
+                   {%- elif dialect == "sqlite" -%}
+                   x.{{ col }} IS y.{{ col }}
                    {%- else -%}
                    x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
                    {%- endif -%}

--- a/src/dbdiff/templates/create_dedup.sql
+++ b/src/dbdiff/templates/create_dedup.sql
@@ -1,5 +1,6 @@
+{% if not use_temp_table and dialect != "vertica" %}CREATE TABLE {{ schema_name }}.{{ table_name_dedup }} AS {% endif -%}
     SELECT x.*
-{% if not use_temp_table %}INTO {{ schema_name }}.{{ table_name_dedup }}{% endif %}
+{% if not use_temp_table and dialect == "vertica" %}INTO {{ schema_name }}.{{ table_name_dedup }}{% endif %}
       FROM {{ schema_name }}.{{ table_name }} x
 INNER JOIN (
     SELECT {{ group_cols }},

--- a/src/dbdiff/templates/create_dup.sql
+++ b/src/dbdiff/templates/create_dup.sql
@@ -1,5 +1,6 @@
+{% if not use_temp_table and dialect != "vertica" %}CREATE TABLE {{ schema_name }}.{{ table_name_dup }} AS {% endif -%}
     SELECT x.*, y.dup_count
-{% if not use_temp_table %}INTO {{ schema_name }}.{{ table_name_dup }}{% endif %}
+{% if not use_temp_table and dialect == "vertica" %}INTO {{ schema_name }}.{{ table_name_dup }}{% endif %}
       FROM {{ schema_name }}.{{ table_name }} x
 INNER JOIN (
     SELECT {{ group_cols }},

--- a/src/dbdiff/templates/create_joined_table_from_selectinto.sql
+++ b/src/dbdiff/templates/create_joined_table_from_selectinto.sql
@@ -19,13 +19,24 @@ CREATE TABLE {{ joined_schema }}.{{ joined_table }} AS
             {% if row.name in join_cols -%}
             COALESCE(x.{{ row.name }}, y.{{ row.name }}) AS {{ row.name -}}
             {% else -%}
+            {%- if dialect == "sqlite" -%}
             CAST(x.{{ row.name }} AS {{ row.x_dtype }}) AS x_{{ row.name }},
             CAST(y.{{ row.name }} AS {{ row.x_dtype }}) AS y_{{ row.name -}}
+            {%- else -%}
+            x.{{ row.name }}::{{ row.x_dtype }} AS x_{{ row.name }},
+            y.{{ row.name }}::{{ row.x_dtype }} AS y_{{ row.name -}}
+            {%- endif -%}
             {%- endif -%}
             {%- if not loop.last %},{% endif -%}
             {%- endfor %}
        FROM {{ x_schema }}.{{ x_table }} AS x
  INNER JOIN {{ y_schema }}.{{ y_table }} AS y
-            ON {% for col in join_cols %}x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}{% if not loop.last %} AND {% endif %}
+            ON {% for col in join_cols -%}
+            {%- if dialect == "sqlite" -%}
+            x.{{ col }} IS y.{{ col }}
+            {%- else -%}
+            x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
+            {%- endif -%}
+            {%- if not loop.last %} AND {% endif %}
             {% endfor %}
 {%- endif %}

--- a/src/dbdiff/templates/create_temp_table.sql
+++ b/src/dbdiff/templates/create_temp_table.sql
@@ -1,1 +1,5 @@
+{% if dialect == "vertica" -%}
 CREATE LOCAL TEMP TABLE {{ table_name }} ON COMMIT PRESERVE ROWS AS ({{ query }})
+{%- else -%}
+CREATE TEMP TABLE {{ table_name }} AS ({{ query }})
+{%- endif %}

--- a/src/dbdiff/templates/insert_joined_table.sql
+++ b/src/dbdiff/templates/insert_joined_table.sql
@@ -14,7 +14,7 @@ INSERT INTO {{ joined_schema }}.{{ joined_table }} (
             {%- if row.name in join_cols -%}
             COALESCE(x.{{ row.name }}, y.{{ row.name }}) AS {{ row.name -}}
             {%- else -%}
-            {%- if dialect == "vertica" -%}
+            {%- if dialect in ("vertica", "postgres", "duckdb") -%}
             x.{{ row.name }}::{{ row.x_dtype }} AS x_{{ row.name }},
             y.{{ row.name }}::{{ row.x_dtype }} AS y_{{ row.name -}}
             {%- else -%}
@@ -29,6 +29,8 @@ INSERT INTO {{ joined_schema }}.{{ joined_table }} (
             ON {% for col in join_cols -%}
             {%- if dialect == "vertica" -%}
             x.{{ col }} <=> y.{{ col }}
+            {%- elif dialect == "sqlite" -%}
+            x.{{ col }} IS y.{{ col }}
             {%- else -%}
             x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
             {%- endif -%}

--- a/src/dbdiff/templates/joined_column.sql
+++ b/src/dbdiff/templates/joined_column.sql
@@ -4,6 +4,8 @@
     FROM {{ joined_schema }}.{{ joined_table }}
    WHERE {% if dialect == "vertica" -%}
    (x_{{ column }} <=> y_{{ column }}) IS FALSE
+   {%- elif dialect == "sqlite" -%}
+   (x_{{ column }} IS NOT y_{{ column }})
    {%- else -%}
    (x_{{ column }} IS DISTINCT FROM y_{{ column }})
    {%- endif %}

--- a/src/dbdiff/templates/joined_column_hier.sql
+++ b/src/dbdiff/templates/joined_column_hier.sql
@@ -6,6 +6,8 @@
              FROM {{ joined_schema }}.{{ joined_table }}
              WHERE {% if dialect == "vertica" -%}
              (x_{{ column }} <=> y_{{ column }}) IS FALSE
+             {%- elif dialect == "sqlite" -%}
+             (x_{{ column }} IS NOT y_{{ column }})
              {%- else -%}
              (x_{{ column }} IS DISTINCT FROM y_{{ column }})
              {%- endif %}

--- a/src/dbdiff/templates/joined_column_raw.sql
+++ b/src/dbdiff/templates/joined_column_raw.sql
@@ -4,6 +4,8 @@
       FROM {{ joined_schema }}.{{ joined_table }}
      WHERE {% if dialect == "vertica" -%}
      (x_{{ column }} <=> y_{{ column }}) IS FALSE
+     {%- elif dialect == "sqlite" -%}
+     (x_{{ column }} IS NOT y_{{ column }})
      {%- else -%}
      (x_{{ column }} IS DISTINCT FROM y_{{ column }})
      {%- endif %}

--- a/src/dbdiff/templates/joined_count.sql
+++ b/src/dbdiff/templates/joined_count.sql
@@ -2,6 +2,8 @@ SELECT COUNT(*)
   FROM {{ joined_schema }}.{{ joined_table }}
  WHERE {% if dialect == "vertica" -%}
  (x_{{ column }} <=> y_{{ column }}) IS FALSE
+ {%- elif dialect == "sqlite" -%}
+ (x_{{ column }} IS NOT y_{{ column }})
  {%- else -%}
  (x_{{ column }} IS DISTINCT FROM y_{{ column }})
  {%- endif %}

--- a/src/dbdiff/templates/joined_rows_count.sql
+++ b/src/dbdiff/templates/joined_rows_count.sql
@@ -3,6 +3,8 @@ SELECT COUNT(*)
  WHERE {% for column in columns -%}
  {%- if dialect == "vertica" -%}
  ((x_{{ column }} <=> y_{{ column }}) IS FALSE)
+ {%- elif dialect == "sqlite" -%}
+ (x_{{ column }} IS NOT y_{{ column }})
  {%- else -%}
  (x_{{ column }} IS DISTINCT FROM y_{{ column }})
  {%- endif -%}

--- a/src/dbdiff/templates/joined_rows_sample.sql
+++ b/src/dbdiff/templates/joined_rows_sample.sql
@@ -3,6 +3,8 @@ SELECT joined.*
  WHERE {% for column in columns -%}
  {%- if dialect == "vertica" -%}
  ((x_{{ column }} <=> y_{{ column }}) IS FALSE)
+ {%- elif dialect == "sqlite" -%}
+ (x_{{ column }} IS NOT y_{{ column }})
  {%- else -%}
  (x_{{ column }} IS DISTINCT FROM y_{{ column }})
  {%- endif -%}

--- a/src/dbdiff/templates/sub_keys_base.sql
+++ b/src/dbdiff/templates/sub_keys_base.sql
@@ -12,6 +12,8 @@ INNER JOIN {{ y_schema }}.{{ y_table }} y
        {%- else -%}
        {%- if dialect == "vertica" -%}
        x.{{ col }} <=> y.{{ col }}
+       {%- elif dialect == "sqlite" -%}
+       x.{{ col }} IS y.{{ col }}
        {%- else -%}
        x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
        {%- endif -%}
@@ -45,6 +47,8 @@ INNER JOIN {{ x_schema }}.{{ x_table }} x
        {%- else -%}
        {%- if dialect == "vertica" -%}
        x.{{ col }} <=> y.{{ col }}
+       {%- elif dialect == "sqlite" -%}
+       x.{{ col }} IS y.{{ col }}
        {%- else -%}
        x.{{ col }} IS NOT DISTINCT FROM y.{{ col }}
        {%- endif -%}

--- a/src/dbdiff/templates/table_columns.sql
+++ b/src/dbdiff/templates/table_columns.sql
@@ -1,5 +1,13 @@
+{% if dialect == "vertica" -%}
 select column_name, data_type
   from columns
  where lower(table_schema) = lower('{{ schema_name }}')
        and lower(table_name) = lower('{{ table_name }}')
  order by ordinal_position
+{%- else -%}
+select column_name, data_type
+  from information_schema.columns
+ where lower(table_schema) = lower('{{ schema_name }}')
+       and lower(table_name) = lower('{{ table_name }}')
+ order by ordinal_position
+{%- endif %}

--- a/src/dbdiff/templates/table_exists.sql
+++ b/src/dbdiff/templates/table_exists.sql
@@ -1,4 +1,11 @@
+{% if dialect == "vertica" -%}
 select COUNT(*)
   from tables
  where table_schema = '{{ schema_name }}'
        and table_name = '{{ table_name }}'
+{%- else -%}
+select COUNT(*)
+  from information_schema.tables
+ where lower(table_schema) = lower('{{ schema_name }}')
+       and lower(table_name) = lower('{{ table_name }}')
+{%- endif %}

--- a/tests/test_duckdb.py
+++ b/tests/test_duckdb.py
@@ -1,0 +1,446 @@
+"""Integration tests using DuckDB as the backend.
+
+These tests mirror the Vertica integration tests but run entirely in-process
+using DuckDB, requiring no external database server.
+
+Run with: pytest tests/test_duckdb.py -m duckdb_integration
+"""
+
+import logging
+
+import pandas as pd
+import pytest
+
+from dbdiff.duckdb_backend import (
+    get_column_info,
+    get_column_info_lookup,
+    get_duckdb_cur,
+    get_table_exists,
+    implicit_dtype_comparison,
+)
+from dbdiff.main import (
+    check_primary_key,
+    create_joined_table,
+    get_column_diffs_from_joined,
+    get_diff_rows_from_joined,
+    get_unmatched_rows,
+    get_unmatched_rows_straight,
+    select_distinct_rows,
+    set_dialect,
+)
+
+pytestmark = pytest.mark.duckdb_integration
+
+logging.basicConfig(format="%(asctime)s - %(message)s", level=logging.INFO)
+
+VALID_COL = {"comparable": True, "exclude": False}
+INT_DTYPES = {d: "INTEGER" for d in {"x_dtype", "y_dtype"}}
+VARCHAR_DTYPES = {d: "VARCHAR" for d in {"x_dtype", "y_dtype"}}
+DATE_DTYPES = {d: "DATE" for d in {"x_dtype", "y_dtype"}}
+COMPARE_COLS = pd.DataFrame(
+    {
+        "data1": {**INT_DTYPES, **VALID_COL},
+        "data2": {**INT_DTYPES, **VALID_COL},
+        "data3": {**DATE_DTYPES, **VALID_COL},
+        "data4": {**VARCHAR_DTYPES, **VALID_COL},
+    }
+).transpose()
+JOIN_COLS = pd.DataFrame(
+    {"join1": {**VARCHAR_DTYPES, **VALID_COL}, "join2": {**VARCHAR_DTYPES, **VALID_COL}}
+).transpose()
+
+
+@pytest.fixture(scope="session")
+def cur():
+    """Create a DuckDB in-memory cursor for the test session."""
+    set_dialect("duckdb")
+    with get_duckdb_cur() as c:
+        yield c
+
+
+def create_schema(cur):
+    cur.execute("CREATE SCHEMA IF NOT EXISTS dbdiff;")
+
+
+def create_x_table(cur):
+    cur.execute(
+        "CREATE TABLE dbdiff.x_table ("
+        " join1 VARCHAR, join2 VARCHAR, missingx INTEGER, missingx2 INTEGER,"
+        " dtypemiss INTEGER, data1 INTEGER, data2 INTEGER, data3 DATE, data4 VARCHAR);"
+    )
+    cur.execute(
+        "INSERT INTO dbdiff.x_table VALUES"
+        " ('match1', 'matchdup21', 0, 0, 0, 0, 0, '2017-10-11', ''),"
+        " ('match1', 'match22', 0, 0, 0, 0, 0, '2017-10-11', 'a'),"
+        " ('match1', 'match23', 0, 0, 0, 1, 1, '2017-10-11', ''),"
+        " ('match1', 'missx21', null, null, null, null, null, null, ''),"
+        " ('match1', 'missx22', null, null, null, null, null, null, ''),"
+        " ('missx11', null, null, null, null, null, null, null, ''),"
+        " ('missx12', null, null, null, null, null, null, null, ''),"
+        " (null, null, null, null, null, null, null, null, '');"
+    )
+
+
+def create_y_table(cur, case_off: bool = False):
+    cur.execute(
+        "CREATE TABLE dbdiff.y_table ("
+        " join1 VARCHAR, join2 VARCHAR, missingy INTEGER,"
+        " dtypemiss DATE, data1 INTEGER, data2 INTEGER, data3 DATE, data4 VARCHAR);"
+    )
+    data4_val = "A" if case_off else "a"
+    cur.execute(
+        "INSERT INTO dbdiff.y_table VALUES"
+        " ('match1', 'matchdup21', 0, '2019-04-22', 0, 0, '2017-10-11', ''),"
+        " ('match1', 'matchdup21', 0, '2019-04-22', 0, 0, '2017-10-11', ''),"
+        f" ('match1', 'match22', 0, '2019-04-22', 0, 1, '2017-10-12', '{data4_val}'),"
+        " ('match1', 'match23', 0, '2019-04-22', 0, 0, '2017-10-13', ''),"
+        " ('match1', 'missy21', 0, '2019-04-22', 0, 0, null, ''),"
+        " ('missy11', null, 0, '2019-04-22', 0, 0, null, '');"
+    )
+
+
+def drop_schema(cur):
+    cur.execute("DROP SCHEMA IF EXISTS dbdiff CASCADE;")
+
+
+def test_drop_data_start(cur):
+    drop_schema(cur)
+
+
+def test_create_data(cur):
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+
+def test_get_column_info(cur):
+    column_info = get_column_info(cur, "dbdiff", "x_table")
+    assert isinstance(column_info, pd.DataFrame)
+    assert "column_name" in column_info.columns
+    assert "data_type" in column_info.columns
+
+
+def test_get_column_info_lookup(cur):
+    column_info_lookup = get_column_info_lookup(cur, "dbdiff", "x_table")
+    assert "data1" in column_info_lookup
+    assert len(column_info_lookup) == 9
+
+
+def test_get_table_exists(cur):
+    assert get_table_exists(cur, "dbdiff", "x_table")
+    assert get_table_exists(cur, "dbdiff", "y_table")
+    assert not get_table_exists(cur, "dbdiff", "z_table")
+
+
+def test_implicit_dtype_comparison():
+    assert implicit_dtype_comparison("INTEGER", "FLOAT")
+    assert implicit_dtype_comparison("VARCHAR", "VARCHAR")
+    assert not implicit_dtype_comparison("INTEGER", "DATE")
+
+
+def test_check_primary_key(cur):
+    assert check_primary_key(cur, "dbdiff", "x_table", ["join1", "join2"]) == 0
+    assert check_primary_key(cur, "dbdiff", "x_table", ["join1"]) == 4
+
+
+def test_select_distinct_rows(cur):
+    x_table_rows = 8
+    x_table_columns = 9
+    new_table_schema, new_table_name = select_distinct_rows(cur, "dbdiff", "x_table", ["join1"])
+    assert get_table_exists(cur, new_table_schema, "x_table_dedup")
+    assert get_table_exists(cur, new_table_schema, "x_table_dup")
+    cur.execute(f"SELECT * FROM {new_table_schema}.{new_table_name}")
+    dedup = pd.DataFrame(cur.fetchall())
+    assert dedup.shape[0] == 3
+    assert dedup.shape[1] == x_table_columns
+    cur.execute(f"SELECT * FROM {new_table_schema}.x_table_dup")
+    dup = pd.DataFrame(cur.fetchall())
+    assert dup.shape[0] == (x_table_rows - dedup.shape[0])
+    assert dup.shape[1] == (x_table_columns + 1)
+
+
+def test_create_joined_table(cur):
+    create_joined_table(
+        cur,
+        x_schema="dbdiff",
+        y_schema="dbdiff",
+        x_table="x_table",
+        y_table="y_table",
+        join_cols=["join1", "join2"],
+        compare_cols=pd.concat([COMPARE_COLS, JOIN_COLS]),
+        joined_schema="dbdiff",
+        joined_table="x_table_JOINED",
+    )
+    assert get_table_exists(cur, "dbdiff", "x_table_JOINED")
+    cur.execute("SELECT * FROM dbdiff.x_table_JOINED")
+    df = pd.DataFrame(cur.fetchall())
+    assert df.shape[0] == 4
+    assert df.shape[1] == ((COMPARE_COLS.shape[0] * 2) + JOIN_COLS.shape[0])
+
+
+def test_get_unmatched_rows_straight(cur):
+    join_cols = ["join1", "join2"]
+    y_minus_x = [2, 1]
+    x_minus_y = [3, 2]
+    results = get_unmatched_rows_straight(
+        cur, "dbdiff", "dbdiff", "x_table", "y_table", join_cols, 100
+    )
+    expected_results = {
+        "x": {"count": sum(x_minus_y), "sample_shape": (sum(x_minus_y), len(join_cols))},
+        "y": {"count": sum(y_minus_x), "sample_shape": (sum(y_minus_x), len(join_cols))},
+    }
+    assert results["x"]["count"] == expected_results["x"]["count"]
+    assert results["x"]["sample"].shape[0] == expected_results["x"]["sample_shape"][0]
+    assert results["x"]["sample"].shape[1] == expected_results["x"]["sample_shape"][1]
+    assert results["y"]["count"] == expected_results["y"]["count"]
+    assert results["y"]["sample"].shape[0] == expected_results["y"]["sample_shape"][0]
+    assert results["y"]["sample"].shape[1] == expected_results["y"]["sample_shape"][1]
+
+
+def test_get_unmatched_rows(cur):
+    join_cols = ["join1", "join2"]
+    y_minus_x = [2, 1]
+    x_minus_y = [3, 2]
+    results = get_unmatched_rows(cur, "dbdiff", "dbdiff", "x_table", "y_table", join_cols, 100)
+    expected_results = {
+        j: {
+            side: {"count": d[i], "sample_shape": (d[i], i + 1)}
+            for side, d in {"x": x_minus_y, "y": y_minus_x}.items()
+        }
+        for i, j in enumerate(join_cols)
+    }
+    for col, expected in expected_results.items():
+        for side, expected_info in expected.items():
+            assert results[col][side]["count"] == expected_info["count"]
+            for i in {0, 1}:
+                assert results[col][side]["sample"].shape[i] == expected_info["sample_shape"][i]
+
+
+def test_get_column_diffs_from_joined(cur):
+    """Test getting column diffs directly from the joined table (no diff table)."""
+    join_cols = ["join1", "join2"]
+
+    all_col_info_df = pd.concat([COMPARE_COLS, JOIN_COLS])
+    comparable_filter = (
+        ~all_col_info_df.exclude
+        & all_col_info_df.comparable
+        & ~all_col_info_df.x_dtype.isnull()
+        & ~all_col_info_df.y_dtype.isnull()
+    )
+
+    grouped_column_diffs = get_column_diffs_from_joined(
+        cur=cur,
+        output_schema="dbdiff",
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        join_cols=join_cols,
+        max_rows_column=100,
+        all_col_info_df=all_col_info_df,
+        comparable_filter=comparable_filter,
+        hierarchical=False,
+    )
+    # data1 has 1 diff, data2 has 2 diffs, data3 has 2 diffs
+    assert len(grouped_column_diffs) > 0
+    for col_name, info in grouped_column_diffs.items():
+        assert "count" in info
+        assert info["count"] > 0
+        assert "df" in info
+        assert "df_raw" in info
+
+
+def test_get_diff_rows_from_joined(cur):
+    """Test getting diff row summary from joined table."""
+    join_cols = ["join1", "join2"]
+
+    all_col_info_df = pd.concat([COMPARE_COLS, JOIN_COLS])
+    comparable_filter = (
+        ~all_col_info_df.exclude
+        & all_col_info_df.comparable
+        & ~all_col_info_df.x_dtype.isnull()
+        & ~all_col_info_df.y_dtype.isnull()
+    )
+
+    grouped_column_diffs = get_column_diffs_from_joined(
+        cur=cur,
+        output_schema="dbdiff",
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        join_cols=join_cols,
+        max_rows_column=100,
+        all_col_info_df=all_col_info_df,
+        comparable_filter=comparable_filter,
+        hierarchical=False,
+    )
+
+    diff_summary = get_diff_rows_from_joined(
+        cur=cur,
+        grouped_column_diffs=grouped_column_diffs,
+        output_schema="dbdiff",
+        x_table="x_table",
+        join_cols=join_cols,
+        max_rows_all=100,
+        skip_row_total=False,
+    )
+    assert "count" in diff_summary
+    assert "total_count" in diff_summary
+    assert diff_summary["total_count"] > 0
+
+
+def test_main_end_to_end(cur):
+    """Full end-to-end test using the main() function from cli.py."""
+    from dbdiff.cli import main
+    from dbdiff.report import html_report
+
+    # Recreate tables to ensure clean state
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=False,
+        hierarchical_join=False,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=False,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    assert "x_schema" in all_info
+    assert "y_schema" in all_info
+    assert "column_info" in all_info
+    assert "diff_summary" in all_info
+    # After dedup of y_table (which has duplicate matchdup21 rows),
+    # only match22 and match23 remain as inner join matches
+    assert all_info["total_row_count"] == 2
+
+    # Generate HTML report
+    report = html_report(**all_info)
+    assert len(report) > 0
+    assert "x_table" in report
+
+
+def test_main_with_hierarchical_join(cur):
+    """Test with hierarchical join enabled."""
+    from dbdiff.cli import main
+
+    # Recreate tables since previous test may have modified state
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=False,
+        hierarchical_join=True,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=False,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    assert "hierarchical_join_info" in all_info
+    assert len(all_info["hierarchical_join_info"]) > 0
+
+
+def test_main_with_use_diff_table(cur):
+    """Test with use_diff_table enabled."""
+    from dbdiff.cli import main
+
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=False,
+        hierarchical_join=False,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=True,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    assert "diff_summary" in all_info
+    assert all_info["diff_summary"]["total_count"] > 0
+
+
+def test_main_with_drop_output_tables(cur):
+    """Test with drop_output_tables enabled."""
+    from dbdiff.cli import main
+
+    drop_schema(cur)
+    create_schema(cur)
+    create_x_table(cur)
+    create_y_table(cur)
+
+    all_info = main(
+        cur=cur,
+        x_schema="dbdiff",
+        x_table="x_table",
+        y_schema="dbdiff",
+        y_table="y_table",
+        output_schema="dbdiff",
+        join_cols=["join1", "join2"],
+        exclude_columns=set(),
+        max_rows_all=10,
+        max_rows_column=10,
+        drop_output_tables=True,
+        hierarchical_join=False,
+        save_column_summary=False,
+        save_column_summary_format="CSV",
+        skip_row_total=False,
+        use_diff_table=False,
+        case_insensitive=False,
+        dialect="duckdb",
+    )
+
+    # After dedup of y_table (which has duplicate matchdup21 rows),
+    # only match22 and match23 remain as inner join matches
+    assert all_info["total_row_count"] == 2
+    # Joined table should have been dropped
+    assert not get_table_exists(cur, "dbdiff", "x_table_JOINED")
+
+
+def test_drop_data_end(cur):
+    drop_schema(cur)

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -9,12 +9,27 @@ from jinja2 import Environment, PackageLoader
 # and sqlglot doesn't have a specific Vertica dialect
 PARSE_DIALECT = "postgres"
 
+# Mapping from dbdiff dialect to sqlglot parse dialect
+DIALECT_TO_SQLGLOT = {
+    "vertica": "postgres",
+    "postgres": "postgres",
+    "duckdb": "duckdb",
+    "sqlite": "sqlite",
+}
+
 
 @pytest.fixture
 def jinja_env():
     """Create a Jinja2 environment for rendering templates."""
     env = Environment(loader=PackageLoader("dbdiff", "templates"))
     env.globals["dialect"] = "vertica"
+    return env
+
+
+def make_jinja_env(dialect):
+    """Create a Jinja2 environment for a specific dialect."""
+    env = Environment(loader=PackageLoader("dbdiff", "templates"))
+    env.globals["dialect"] = dialect
     return env
 
 
@@ -426,3 +441,219 @@ class TestSQLTemplateRendering:
             columns=["amount", "name"],
         )
         sqlglot.parse(sql, dialect=PARSE_DIALECT, error_level=sqlglot.ErrorLevel.RAISE)
+
+
+@pytest.fixture(params=["postgres", "duckdb", "sqlite"])
+def dialect_env(request):
+    """Parametrized fixture providing (jinja_env, sqlglot_dialect) for each target dialect."""
+    dialect = request.param
+    env = make_jinja_env(dialect)
+    return env, DIALECT_TO_SQLGLOT[dialect]
+
+
+@pytest.fixture
+def dialect_compare_cols():
+    """Sample dataframe for compare_cols with multiple columns."""
+    return pd.DataFrame(
+        {
+            "x_dtype": ["INTEGER", "VARCHAR(100)", "FLOAT", "DATE"],
+            "y_dtype": ["INTEGER", "VARCHAR(100)", "FLOAT", "DATE"],
+        },
+        index=["id", "name", "amount", "created_at"],
+    )
+
+
+@pytest.fixture
+def dialect_join_cols():
+    """Sample join column list."""
+    return ["id"]
+
+
+class TestDialectTemplateRendering:
+    """Test that dialect-specific SQL templates render and parse correctly for postgres, duckdb, and sqlite."""
+
+    def test_create_joined_table(self, dialect_env, dialect_compare_cols, dialect_join_cols):
+        """Test create_joined_table.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("create_joined_table.sql")
+        sql = template.render(
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            compare_cols=dialect_compare_cols,
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_create_joined_table_from_selectinto(
+        self, dialect_env, dialect_compare_cols, dialect_join_cols
+    ):
+        """Test create_joined_table_from_selectinto.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("create_joined_table_from_selectinto.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            compare_cols=dialect_compare_cols,
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_insert_joined_table(self, dialect_env, dialect_compare_cols, dialect_join_cols):
+        """Test insert_joined_table.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("insert_joined_table.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            compare_cols=dialect_compare_cols,
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_all_keys_count(self, dialect_env, dialect_join_cols):
+        """Test all_keys_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("all_keys_count.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=dialect_join_cols,
+            x=True,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_all_keys_sample(self, dialect_env, dialect_join_cols):
+        """Test all_keys_sample.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("all_keys_sample.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=dialect_join_cols,
+            x=True,
+            max_rows_column=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_sub_keys_count(self, dialect_env):
+        """Test sub_keys_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("sub_keys_count.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=["id", "name"],
+            x=True,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_sub_keys_sample(self, dialect_env):
+        """Test sub_keys_sample.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("sub_keys_sample.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=["id", "name"],
+            x=True,
+            max_rows_column=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_sub_keys_grouped(self, dialect_env):
+        """Test sub_keys_grouped.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("sub_keys_grouped.sql")
+        sql = template.render(
+            x_schema="x_schema",
+            y_schema="y_schema",
+            x_table="x_table",
+            y_table="y_table",
+            join_cols=["id", "name"],
+            x=True,
+            max_rows_column=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_count(self, dialect_env):
+        """Test joined_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_count.sql")
+        sql = template.render(
+            column="amount", joined_schema="output_schema", joined_table="joined_table"
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_column(self, dialect_env):
+        """Test joined_column.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_column.sql")
+        sql = template.render(
+            column="amount", joined_schema="output_schema", joined_table="joined_table"
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_column_raw(self, dialect_env, dialect_join_cols):
+        """Test joined_column_raw.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_column_raw.sql")
+        sql = template.render(
+            column="amount",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            join_cols=dialect_join_cols,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_column_hier(self, dialect_env, dialect_join_cols):
+        """Test joined_column_hier.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_column_hier.sql")
+        sql = template.render(
+            column="amount",
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            join_cols=dialect_join_cols,
+            schema="x_schema",
+            table="x_table",
+            limit=10,
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_rows_count(self, dialect_env):
+        """Test joined_rows_count.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_rows_count.sql")
+        sql = template.render(
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            columns=["amount", "name"],
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)
+
+    def test_joined_rows_sample(self, dialect_env):
+        """Test joined_rows_sample.sql renders valid SQL for target dialect."""
+        env, parse_dialect = dialect_env
+        template = env.get_template("joined_rows_sample.sql")
+        sql = template.render(
+            joined_schema="output_schema",
+            joined_table="joined_table",
+            columns=["amount", "name"],
+        )
+        sqlglot.parse(sql, dialect=parse_dialect, error_level=sqlglot.ErrorLevel.RAISE)

--- a/uv.lock
+++ b/uv.lock
@@ -266,9 +266,15 @@ dependencies = [
     { name = "xlsxwriter" },
 ]
 
+[package.optional-dependencies]
+duckdb = [
+    { name = "duckdb" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "click" },
+    { name = "duckdb" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "sqlglot" },
@@ -278,6 +284,7 @@ dev = [
 requires-dist = [
     { name = "charset-normalizer", specifier = "<3.4.5" },
     { name = "click" },
+    { name = "duckdb", marker = "extra == 'duckdb'" },
     { name = "jinja2" },
     { name = "numpy", specifier = "<2.4.3" },
     { name = "pandas", specifier = ">=1.0.0" },
@@ -286,13 +293,57 @@ requires-dist = [
     { name = "vertica-python" },
     { name = "xlsxwriter" },
 ]
+provides-extras = ["duckdb"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "click" },
+    { name = "duckdb" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "sqlglot" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/11/e05a7eb73a373d523e45d83c261025e02bc31ebf868e6282c30c4d02cc59/duckdb-1.5.0.tar.gz", hash = "sha256:f974b61b1c375888ee62bc3125c60ac11c4e45e4457dd1bb31a8f8d3cf277edd", size = 17981141, upload_time = "2026-03-09T12:50:26.372Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/8fa129bbd604d0e91aa9a0a407e7d2acc559b6024c3f887868fd7a13871d/duckdb-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:47fbb1c053a627a91fa71ec883951561317f14a82df891c00dcace435e8fea78", size = 30012348, upload_time = "2026-03-09T12:48:39.133Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/31/db320641a262a897755e634d16838c98d5ca7dc91f4e096e104e244a3a01/duckdb-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2b546a30a6ac020165a86ab3abac553255a6e8244d5437d17859a6aa338611aa", size = 15940515, upload_time = "2026-03-09T12:48:41.905Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/45/5725684794fbabf54d8dbae5247685799a6bf8e1e930ebff3a76a726772c/duckdb-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:122396041c0acb78e66d7dc7d36c55f03f67fe6ad012155c132d82739722e381", size = 14193724, upload_time = "2026-03-09T12:48:44.105Z" },
+    { url = "https://files.pythonhosted.org/packages/27/68/f110c66b43e27191d7e53d3587e118568b73d66f23cb9bd6c7e0a560fd6d/duckdb-1.5.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a2cd73d50ea2c2bf618a4b7d22fe7c4115a1c9083d35654a0d5d421620ed999", size = 19218777, upload_time = "2026-03-09T12:48:46.399Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9d/46affc9257377cbc865e494650312a7a08a56e85aa8d702eb297bec430b7/duckdb-1.5.0-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63a8ea3b060a881c90d1c1b9454abed3daf95b6160c39bbb9506fee3a9711730", size = 21311205, upload_time = "2026-03-09T12:48:48.895Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/34/dac03ab7340989cda258655387959c88342ea3b44949751391267bcbc830/duckdb-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:238d576ae1dda441f8c79ed1370c5ccf863e4a5d59ca2563f9c96cd26b2188ac", size = 13043217, upload_time = "2026-03-09T12:48:51.262Z" },
+    { url = "https://files.pythonhosted.org/packages/01/0c/0282b10a1c96810606b916b8d58a03f2131bd3ede14d2851f58b0b860e7c/duckdb-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:3298bd17cf0bb5f342fb51a4edc9aadacae882feb2b04161a03eb93271c70c86", size = 30014615, upload_time = "2026-03-09T12:48:54.061Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e8/cbbc920078a794f24f63017fc55c9cbdb17d6fb94d3973f479b2d9f2983d/duckdb-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:13f94c49ca389731c439524248e05007fb1a86cd26f1e38f706abc261069cd41", size = 15940493, upload_time = "2026-03-09T12:48:57.85Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b6/6cae794d5856259b0060f79d5db71c7fdba043950eaa6a9d72b0bad16095/duckdb-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ab9d597b1e8668466f1c164d0ea07eaf0ebb516950f5a2e794b0f52c81ff3b16", size = 14194663, upload_time = "2026-03-09T12:49:00.416Z" },
+    { url = "https://files.pythonhosted.org/packages/82/07/aba3887658b93a36ce702dd00ca6a6422de3d14c7ee3a4b4c03ea20a99c0/duckdb-1.5.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a43f8289b11c0b50d13f96ab03210489d37652f3fd7911dc8eab04d61b049da2", size = 19220501, upload_time = "2026-03-09T12:49:03.431Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a2/723e6df48754e468fa50d7878eb860906c975eafe317c4134a8482ca220e/duckdb-1.5.0-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f514e796a116c5de070e99974e42d0b8c2e6c303386790e58408c481150d417", size = 21316142, upload_time = "2026-03-09T12:49:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/03/af/4dcbdf8f2349ed0b054c254ec59bc362ce6ddf603af35f770124c0984686/duckdb-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:cf503ba2c753d97c76beb111e74572fef8803265b974af2dca67bba1de4176d2", size = 13043445, upload_time = "2026-03-09T12:49:08.892Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5e/1bb7e75a63bf3dc49bc5a2cd27a65ffeef151f52a32db980983516f2d9f6/duckdb-1.5.0-cp311-cp311-win_arm64.whl", hash = "sha256:a1156e91e4e47f0e7d9c9404e559a1d71b372cd61790a407d65eb26948ae8298", size = 13883145, upload_time = "2026-03-09T12:49:11.566Z" },
+    { url = "https://files.pythonhosted.org/packages/43/73/120e673e48ae25aaf689044c25ef51b0ea1d088563c9a2532612aea18e0a/duckdb-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9ea988d1d5c8737720d1b2852fd70e4d9e83b1601b8896a1d6d31df5e6afc7dd", size = 30057869, upload_time = "2026-03-09T12:49:14.65Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e9/61143471958d36d3f3e764cb4cd43330be208ddbff1c78d3310b9ee67fe8/duckdb-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:cb786d5472afc16cc3c7355eb2007172538311d6f0cc6f6a0859e84a60220375", size = 15963092, upload_time = "2026-03-09T12:49:17.478Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/71/76e37c9a599ad89dd944e6cbb3e6a8ad196944a421758e83adea507637b6/duckdb-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dc92b238f4122800a7592e99134124cc9048c50f766c37a0778dd2637f5cbe59", size = 14220562, upload_time = "2026-03-09T12:49:23.518Z" },
+    { url = "https://files.pythonhosted.org/packages/db/b8/de1831656d5d13173e27c79c7259c8b9a7bdc314fdc8920604838ea4c46d/duckdb-1.5.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b74cb205c21d3696d8f8b88adca401e1063d6e6f57c1c4f56a243610b086e30", size = 19245329, upload_time = "2026-03-09T12:49:26.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/8d/33d349a3bcbd3e9b7b4e904c19d5b97f058c4c20791b89a8d6323bb93dce/duckdb-1.5.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e56c19ffd1ffe3642fa89639e71e2e00ab0cf107b62fe16e88030acaebcbde6", size = 21348041, upload_time = "2026-03-09T12:49:30.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ec/591a4cad582fae04bc8f8b4a435eceaaaf3838cf0ca771daae16a3c2995b/duckdb-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:86525e565ec0c43420106fd34ba2c739a54c01814d476c7fed3007c9ed6efd86", size = 13053781, upload_time = "2026-03-09T12:49:33.574Z" },
+    { url = "https://files.pythonhosted.org/packages/db/62/42e0a13f9919173bec121c0ff702406e1cdd91d8084c3e0b3412508c3891/duckdb-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:5faeebc178c986a7bfa68868a023001137a95a1110bf09b7356442a4eae0f7e7", size = 13862906, upload_time = "2026-03-09T12:49:36.598Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5d/af5501221f42e4e3662c047ecec4dcd0761229fceeba3c67ad4d9d8741df/duckdb-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11dd05b827846c87f0ae2f67b9ae1d60985882a7c08ce855379e4a08d5be0e1d", size = 30057396, upload_time = "2026-03-09T12:49:39.95Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bd/a278d73fedbd3783bf9aedb09cad4171fe8e55bd522952a84f6849522eb6/duckdb-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ad8d9c91b7c280ab6811f59deff554b845706c20baa28c4e8f80a95690b252b", size = 15962700, upload_time = "2026-03-09T12:49:43.504Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fc/c916e928606946209c20fb50898dabf120241fb528a244e2bd8cde1bd9e2/duckdb-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0ee4dabe03ed810d64d93927e0fd18cd137060b81ee75dcaeaaff32cbc816656", size = 14220272, upload_time = "2026-03-09T12:49:46.867Z" },
+    { url = "https://files.pythonhosted.org/packages/53/07/1390e69db922423b2e111e32ed342b3e8fad0a31c144db70681ea1ba4d56/duckdb-1.5.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9409ed1184b363ddea239609c5926f5148ee412b8d9e5ffa617718d755d942f6", size = 19244401, upload_time = "2026-03-09T12:49:49.865Z" },
+    { url = "https://files.pythonhosted.org/packages/54/13/b58d718415cde993823a54952ea511d2612302f1d2bc220549d0cef752a4/duckdb-1.5.0-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1df8c4f9c853a45f3ec1e79ed7fe1957a203e5ec893bbbb853e727eb93e0090f", size = 21345827, upload_time = "2026-03-09T12:49:52.977Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/96/4460429651e371eb5ff745a4790e7fa0509c7a58c71fc4f0f893404c9646/duckdb-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:9a3d3dfa2d8bc74008ce3ad9564761ae23505a9e4282f6a36df29bd87249620b", size = 13053101, upload_time = "2026-03-09T12:49:56.134Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/6d5b805113214b830fa3c267bb3383fb8febaa30760d0162ef59aadb110a/duckdb-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:2deebcbafd9d39c04f31ec968f4dd7cee832c021e10d96b32ab0752453e247c8", size = 13865071, upload_time = "2026-03-09T12:49:59.282Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9f/dd806d4e8ecd99006eb240068f34e1054533da1857ad06ac726305cd102d/duckdb-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d4b618de670cd2271dd7b3397508c7b3c62d8ea70c592c755643211a6f9154fa", size = 30065704, upload_time = "2026-03-09T12:50:02.671Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c2/7b7b8a5c65d5535c88a513e267b5e6d7a55ab3e9b67e4ddd474454653268/duckdb-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:065ae50cb185bac4b904287df72e6b4801b3bee2ad85679576dd712b8ba07021", size = 15964883, upload_time = "2026-03-09T12:50:06.343Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c5/9a52a2cdb228b8d8d191a603254364d929274d9cc7d285beada8f7daa712/duckdb-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6be5e48e287a24d98306ce9dd55093c3b105a8fbd8a2e7a45e13df34bf081985", size = 14221498, upload_time = "2026-03-09T12:50:10.567Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/68/646045cb97982702a8a143dc2e45f3bdcb79fbe2d559a98d74b8c160e5e2/duckdb-1.5.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5ee41a0bf793882f02192ce105b9a113c3e8c505a27c7ef9437d7b756317113", size = 19249787, upload_time = "2026-03-09T12:50:13.524Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/5abf0c7f38febb3b4a231c784223fceccfd3f2bfd957699d786f46e41ce6/duckdb-1.5.0-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8e42aaf3cd217417c5dc9ff522dc3939d18b25a6fe5f846348277e831e6f59c", size = 21351583, upload_time = "2026-03-09T12:50:16.701Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a4/a90f2901cc0a1ce7ca4f0564b8492b9dbfe048a6395b27933d46ae9be473/duckdb-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:11ae50aaeda2145b50294ee0247e4f11fb9448b3cc3d2aea1cfc456637dfb977", size = 13575130, upload_time = "2026-03-09T12:50:19.716Z" },
+    { url = "https://files.pythonhosted.org/packages/64/aa/f14dd5e241ec80d9f9d82196ca65e0c53badfc8a7a619d5497c5626657ad/duckdb-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:d6d2858c734d1a7e7a1b6e9b8403b3fce26dfefb4e0a2479c420fba6cd36db36", size = 14341879, upload_time = "2026-03-09T12:50:22.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR combines and enhances the work from **PR #13** (DuckDB backend) and **PR #14** (dialect parser) into a unified multi-dialect support feature.

### What's Combined

**From PR #13 (DuckDB backend):**
- New `duckdb_backend.py` with cursor wrapper and connection manager
- DuckDB integration tests (`test_duckdb.py` - 18 tests)
- DuckDB-specific SQL template modifications

**From PR #14 (Dialect parser):**
- Comprehensive SQL template dialect support for all 12+ templates
- Click.Choice validation for `--dialect` CLI option
- Parametrized sqlglot syntax tests (`test_sql.py` - 42 tests covering postgres/duckdb/sqlite)

**Enhanced Integration:**
- Fixed temp table handling for non-Vertica dialects
- Dialect-aware backend dispatch in `cli.py`
- Null-safe equality handling across all dialects in `main.py`

### Key Features

- **DuckDB backend** for in-process table comparison (no external DB server required)
- **SQL template dialect support** for PostgreSQL, DuckDB, and SQLite
- **Dialect-specific null-safe equality** operators:
  - Vertica: `<=>` 
  - PostgreSQL/DuckDB: `IS NOT DISTINCT FROM`
  - SQLite: `IS`
- **Type casting syntax** handling (::TYPE vs CAST)
- **Table creation syntax** (SELECT INTO vs CREATE TABLE AS)

### Implementation Details

**New Files:**
- `src/dbdiff/duckdb_backend.py` - DuckDB cursor wrapper and connection manager
- `tests/test_duckdb.py` - 18 integration tests using DuckDB

**Modified Files:**
- `src/dbdiff/cli.py` - Dialect-based backend dispatch, click.Choice validation
- `src/dbdiff/main.py` - Dialect-aware execution with `_current_dialect` global
- `src/dbdiff/templates/*.sql` - 12+ templates updated with dialect conditionals
- `tests/test_sql.py` - 42 parametrized tests for postgres/duckdb/sqlite
- `pyproject.toml` - Added duckdb optional dependency

### Testing

All tests pass (156 passed, 17 skipped):
- ✅ 18 DuckDB integration tests (no external DB required)
- ✅ 42 parametrized sqlglot syntax tests across 3 dialects
- ✅ All existing Vertica tests remain compatible (skipped when VERTICA_HOST not set)

### Closes

Closes #9, #10, #11

## Test Plan

Run the test suite:
```bash
uv run pytest
```

Try DuckDB backend:
```bash
dbdiff --dialect duckdb ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)